### PR TITLE
Fixed word wrap overflow in tooltip

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/ui/Tooltip.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/ui/Tooltip.java
@@ -35,7 +35,6 @@ public class Tooltip {
 
         tooltipLabel = new Label("", UiSkin.getSkin().get(Label.LabelStyle.class));
         tooltipLabel.setWrap(true);
-        tooltipLabel.setFillParent(true);
 
         tooltipInnerTable = new Table();
         tooltipInnerTable.add(tooltipLabel).width(320f).row();


### PR DESCRIPTION
Original code was calling setFillParent, which should only typically be done on the root table. This was causing the word wrapping of the label to extend past the bottom of the root table after the font scale was changed. This was a problem for tooltips of items with long names.