### PR TITLE
Fix flatten tiles and control points not refreshing

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorFrame.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorFrame.java
@@ -1598,7 +1598,7 @@ public class EditorFrame implements ApplicationListener {
 		tesselators.waterfall.addCollisionTriangles(triangleSpatialHash);
 	}
 
-	private void refreshEntity(Entity theEntity) {
+	protected void refreshEntity(Entity theEntity) {
 		if(theEntity instanceof Light && showLights) {
 			refreshLights();
 		}

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorFrame.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorFrame.java
@@ -65,6 +65,7 @@ import com.interrupt.helpers.TileEdges;
 import com.interrupt.managers.EntityManager;
 import com.interrupt.managers.StringManager;
 import com.noise.PerlinNoise;
+import com.badlogic.gdx.math.MathUtils;
 
 import javax.swing.*;
 import java.util.HashMap;
@@ -507,6 +508,11 @@ public class EditorFrame implements ApplicationListener {
 	Vector3 intersectNormal = new Vector3();
 	Vector3 intersectTemp = new Vector3();
 	Array<Entity> selectedEntities = new Array<Entity>();
+
+	// Track the starting point of the selection area.
+	int selStartX = 0;
+	int selStartY = 0;
+
 	public void draw() {
 		GL20 gl = renderer.getGL();
         GlRenderer.clearBoundTexture();
@@ -755,6 +761,9 @@ public class EditorFrame implements ApplicationListener {
 				if(selectionY >= level.height) selectionY = level.height - 1;
 
                 selectionWidth = selectionHeight = 1;
+				selStartX = selectionX;
+				selStartY = selectionY;
+				controlPoints.clear();
 			}
 			else if(editorInput.isButtonPressed(Input.Buttons.LEFT)) {
 				if(Gdx.input.isKeyPressed(Keys.ALT_LEFT)) {
@@ -778,17 +787,15 @@ public class EditorFrame implements ApplicationListener {
 						// don't modify selection area!
 						movingControlPoint = true;
 					} else {
+						// The user is dragging the selection area to set its size. Update the selection area based on their mouse position.
+						int newX = MathUtils.clamp((int) intpos.x, 0, level.width - 1);
+						int newY = MathUtils.clamp((int) intpos.z, 0, level.height - 1);
 
-						float selectXMod = 0.8f;
-						float selectYMod = 0.8f;
-						if (intpos.x < selectionX) selectXMod *= -1f;
-						if (intpos.z < selectionY) selectYMod *= -1f;
-
-						selectionWidth = ((int) (intpos.x + selectXMod) - selectionX);
-						selectionHeight = ((int) (intpos.z + selectYMod) - selectionY);
-
-						if (selectionWidth == 0) selectionWidth = 1;
-						if (selectionHeight == 0) selectionHeight = 1;
+						selectionWidth = Math.abs(selStartX - newX) + 1;
+						selectionHeight = Math.abs(selStartY - newY) + 1;
+						// Always make this the lowest corner so that the selection size, which is relative to this, is positive.
+						selectionX = Math.min(newX, selStartX);
+						selectionY = Math.min(newY, selStartY);
 
 						controlPoints.clear();
 					}
@@ -916,17 +923,6 @@ public class EditorFrame implements ApplicationListener {
 			int selY = selectionY;
 			int selWidth = selectionWidth;
 			int selHeight = selectionHeight;
-
-			if(selWidth < 0) {
-				selX = selX + selWidth;
-				selWidth *= -1;
-				selX += 1;
-			}
-			if(selHeight < 0) {
-				selY = selY + selHeight;
-				selHeight *= -1;
-				selY += 1;
-			}
 
 			Tile startTile = level.getTile(selectionX, selectionY);
 
@@ -1085,17 +1081,6 @@ public class EditorFrame implements ApplicationListener {
 				int selY = selectionY;
 				int selWidth = selectionWidth;
 				int selHeight = selectionHeight;
-
-				if(selWidth < 0) {
-					selX = selX + selWidth;
-					selWidth *= -1;
-					selX += 1;
-				}
-				if(selHeight < 0) {
-					selY = selY + selHeight;
-					selHeight *= -1;
-					selY += 1;
-				}
 
 				for(int x = selX; x < selX + selWidth; x++) {
 					for(int y = selY; y < selY + selHeight; y++) {
@@ -1855,17 +1840,6 @@ public class EditorFrame implements ApplicationListener {
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
 
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
-
 		for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {
 				Tile t = level.getTileOrNull(x,y);
@@ -2212,22 +2186,6 @@ public class EditorFrame implements ApplicationListener {
 
 			player.xa += (xm * Math.cos(rotX) + zm * Math.sin(rotX)) * 0.025f * Math.min(player.friction * 1.4f, 1f);
 			player.ya += (zm * Math.cos(rotX) - xm * Math.sin(rotX)) * 0.025f * Math.min(player.friction * 1.4f, 1f);
-		}
-
-		int selX = selectionX;
-		int selY = selectionY;
-		int selWidth = selectionWidth;
-		int selHeight = selectionHeight;
-
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
 		}
 
 		// Tile editing mode?
@@ -2847,17 +2805,6 @@ public class EditorFrame implements ApplicationListener {
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
 
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
-
 	   clearSelectedMarkers();
 
 	   if(selectedItem != Markers.none) {
@@ -2879,17 +2826,6 @@ public class EditorFrame implements ApplicationListener {
 		int selY = selectionY;
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
-
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
 
 	   for(EditorMarker marker : level.editorMarkers) {
 		   if(marker.x >= selX && marker.x < selX + selWidth && marker.y >= selY && marker.y < selY + selHeight) return true;
@@ -2925,17 +2861,6 @@ public class EditorFrame implements ApplicationListener {
 		int selY = selectionY;
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
-
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
 
 	   for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {
@@ -2994,17 +2919,6 @@ public class EditorFrame implements ApplicationListener {
 		int selY = selectionY;
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
-
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
 
 		Tile selected = level.getTile(selectionX, selectionY);
 
@@ -3107,17 +3021,6 @@ public class EditorFrame implements ApplicationListener {
 		int selY = selectionY;
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
-
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
 
 		for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {
@@ -3241,17 +3144,6 @@ public class EditorFrame implements ApplicationListener {
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
 
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
-
 		for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {
 				Tile n = level.getTile(x, y - 1);
@@ -3283,17 +3175,6 @@ public class EditorFrame implements ApplicationListener {
 		int selY = selectionY;
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
-
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
 
 		for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {
@@ -3341,17 +3222,6 @@ public class EditorFrame implements ApplicationListener {
         int selWidth = selectionWidth;
         int selHeight = selectionHeight;
 
-        if(selWidth < 0) {
-            selX = selX + selWidth;
-            selWidth *= -1;
-            selX += 1;
-        }
-        if(selHeight < 0) {
-            selY = selY + selHeight;
-            selHeight *= -1;
-            selY += 1;
-        }
-
         if(pickedEntity == null) {
             clipboard.tiles = new Tile[selWidth][selHeight];
             clipboard.selWidth = selWidth;
@@ -3377,17 +3247,6 @@ public class EditorFrame implements ApplicationListener {
         if(clipboard != null) {
             int selX = selectionX;
             int selY = selectionY;
-            int selWidth = selectionWidth;
-            int selHeight = selectionHeight;
-
-            if(selWidth < 0) {
-                selX = selX + selWidth;
-                selX += 1;
-            }
-            if(selHeight < 0) {
-                selY = selY + selHeight;
-                selY += 1;
-            }
 
             for(int x = 0; x < clipboard.selWidth; x++) {
                 for(int y = 0; y < clipboard.selHeight; y++) {
@@ -3429,17 +3288,6 @@ public class EditorFrame implements ApplicationListener {
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
 
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
-
 		for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {
 				Tile t = level.getTileOrNull(x,y);
@@ -3462,17 +3310,6 @@ public class EditorFrame implements ApplicationListener {
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
 
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
-
 		for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {
 				Tile t = level.getTileOrNull(x,y);
@@ -3492,17 +3329,6 @@ public class EditorFrame implements ApplicationListener {
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
 
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
-
 		for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {
 				Tile t = level.getTileOrNull(x,y);
@@ -3519,17 +3345,6 @@ public class EditorFrame implements ApplicationListener {
 		int selY = selectionY;
 		int selWidth = selectionWidth;
 		int selHeight = selectionHeight;
-
-		if(selWidth < 0) {
-			selX = selX + selWidth;
-			selWidth *= -1;
-			selX += 1;
-		}
-		if(selHeight < 0) {
-			selY = selY + selHeight;
-			selHeight *= -1;
-			selY += 1;
-		}
 
 		for(int x = selX; x < selX + selWidth; x++) {
 			for(int y = selY; y < selY + selHeight; y++) {

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorRightClickMenu.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorRightClickMenu.java
@@ -31,6 +31,7 @@ public class EditorRightClickMenu extends Scene2dMenu {
     	MenuItem toJson = new MenuItem("To JSON", skin);
 		MenuItem onFloor = new MenuItem("Move to Floor", skin);
 		MenuItem onCeiling = new MenuItem("Move to Ceiling", skin);
+		MenuItem center = new MenuItem("Center in Tile", skin);
     	
     	if(e instanceof Group && !(e instanceof Prefab)) {
     		MenuItem unGroup = new MenuItem("Ungroup", skin);
@@ -84,16 +85,27 @@ public class EditorRightClickMenu extends Scene2dMenu {
 			public void actionPerformed(ActionEvent event) {
 				float floorHeight = lvl.getTile((int)entity.x, (int)entity.y).getFloorHeight(entity.x, entity.y);
 				entity.z = floorHeight + 0.5f;
+				editor.refreshEntity(entity);
 			}
 		});
 
-		addItem(onCeiling);
+	addItem(onCeiling);
 		onCeiling.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent event) {
 				float ceilHeight = lvl.getTile((int)entity.x, (int)entity.y).getCeilHeight(entity.x, entity.y);
 				entity.z = ceilHeight - entity.collision.z + 0.5f;
+				editor.refreshEntity(entity);
 			}
 		});
+
+        addItem(center);
+		center.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent event) {
+				entity.x = (int)entity.x + 0.5f;
+				entity.y = (int)entity.y + 0.5f;
+				editor.refreshEntity(entity);
+			}
+		});		
     }
     
     public EditorRightClickMenu(final Entity main, final Array<Entity> additionalSelected, final EditorFrame editor, final JFrame window, final Level level) {
@@ -147,6 +159,7 @@ public class EditorRightClickMenu extends Scene2dMenu {
 
 		MenuItem onFloor = new MenuItem("Move to Floor", skin);
 		MenuItem onCeiling = new MenuItem("Move to Ceiling", skin);
+		MenuItem center = new MenuItem("Center in Tile", skin);
 
 		addItem(onFloor);
 		onFloor.addActionListener(new ActionListener() {
@@ -158,6 +171,7 @@ public class EditorRightClickMenu extends Scene2dMenu {
 				for(Entity entity : allSelected) {
 					float floorHeight = level.getTile((int) entity.x, (int) entity.y).getFloorHeight(entity.x, entity.y);
 					entity.z = floorHeight + 0.5f;
+					editor.refreshEntity(entity);
 				}
 			}
 		});
@@ -172,6 +186,22 @@ public class EditorRightClickMenu extends Scene2dMenu {
 				for(Entity entity : allSelected) {
 					float ceilHeight = level.getTile((int) entity.x, (int) entity.y).getCeilHeight(entity.x, entity.y);
 					entity.z = ceilHeight - entity.collision.z + 0.5f;
+					editor.refreshEntity(entity);
+				}
+			}
+		});
+
+		addItem(center);
+		center.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent event) {
+				Array<Entity> allSelected = new Array<Entity>();
+				allSelected.add(main);
+				allSelected.addAll(additionalSelected);
+
+				for(Entity entity : allSelected) {
+					entity.x = (int)entity.x + 0.5f;
+					entity.y = (int)entity.y + 0.5f;
+					editor.refreshEntity(entity);
 				}
 			}
 		});

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/Tesselator.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/Tesselator.java
@@ -638,7 +638,7 @@ public class Tesselator {
 							if (c.isSky() && isOtherSolid) {
 								// This makes the edge of an outdoor map transparent for sky tiles.
 								showWall = false;
-							} else if (isOtherSky && isOtherFloorHigher) {
+							} else if (isOtherSky && (isOtherFloorHigher && !isOtherSolid)) {
 								// Make sure we show the lower portion of a raised sky tile.
 								showWall = true;
 							} else {


### PR DESCRIPTION
Two main fixes in this one:
* The flatten tile wouldn't work with a negative selection width or height. A lot of other methods had if logic to handle, so I fixed at the source (where width and height are set) and then removed the logic in all of the other places. No need to remember to cut and paste that logic any more.
* When selecting a new tile it would not always clear the control points from the old tiles. I added a control point clear on selection of a new tile, so now the control point will move to the newly selected tile right away (no need to re-click or toggle vertex mode or anything).