### PR TITLE
Adding a LevelSwap trigger that can replace some tiles of the currently loaded level on the fly

### DIFF
--- a/Dungeoneer/assets/data/entities.dat
+++ b/Dungeoneer/assets/data/entities.dat
@@ -78,6 +78,7 @@
 			"DamageTrigger": { class: com.interrupt.dungeoneer.entities.triggers.DamageTrigger, floating: true, isSolid: true },
 			"LookAtTrigger": { class: com.interrupt.dungeoneer.entities.triggers.LookAtTrigger, floating: true},
 			"DeleteTrigger": { class: com.interrupt.dungeoneer.entities.triggers.TriggeredDelete, floating: true, triggerType: "PLAYER_TOUCHED" },
+			"LevelSwapTrigger": { class: com.interrupt.dungeoneer.entities.triggers.LevelSwap, floating: true, triggerType: "PLAYER_TOUCHED", triggerResets: false },
 			"InventoryCheck": { class: com.interrupt.dungeoneer.entities.triggers.TriggeredInventoryCheck, floating: true, triggerType: "PLAYER_TOUCHED" },
 			"Lever": {
 				class: com.interrupt.dungeoneer.entities.Group,

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/triggers/LevelSwap.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/triggers/LevelSwap.java
@@ -1,0 +1,42 @@
+package com.interrupt.dungeoneer.entities.triggers;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.interrupt.dungeoneer.GameManager;
+import com.interrupt.dungeoneer.annotations.EditorProperty;
+import com.interrupt.dungeoneer.game.Game;
+import com.interrupt.dungeoneer.game.Level;
+import com.interrupt.dungeoneer.serializers.v2.LevelSerializer;
+
+public class LevelSwap extends Trigger {
+
+    @EditorProperty
+    public String levelFilename;
+
+    public LevelSwap() { }
+
+    // triggers can be delayed, fire the actual trigger here
+    public void doTriggerEvent(String value) {
+        super.doTriggerEvent(value);
+
+        // Load and place a level into this area
+        // TODO: do this in a thread?
+        try {
+            FileHandle levelFile = Game.findInternalFileInMods(levelFilename);
+            Level level = LevelSerializer.loadLevel(levelFile);
+            if (level != null) {
+                Level currentLevel = Game.GetLevel();
+                currentLevel.paste(level, (int) x - level.width / 2, (int) y - level.height / 2);
+
+                currentLevel.initEntities(level.entities, Level.Source.LEVEL_START);
+                currentLevel.initEntities(level.static_entities, Level.Source.LEVEL_START);
+                currentLevel.initEntities(level.non_collidable_entities, Level.Source.LEVEL_START);
+
+                currentLevel.updateLights(Level.Source.SPAWNED);
+                GameManager.renderer.refreshChunksNear(x, y, Math.max(level.width, level.height));
+            }
+        } catch (Exception ex) {
+            Gdx.app.log("LevelSwapTrigger", ex.getMessage());
+        }
+    }
+}

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/triggers/LevelSwap.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/triggers/LevelSwap.java
@@ -7,6 +7,7 @@ import com.interrupt.dungeoneer.annotations.EditorProperty;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.serializers.v2.LevelSerializer;
+import com.interrupt.dungeoneer.tiles.Tile;
 
 public class LevelSwap extends Trigger {
 
@@ -14,6 +15,8 @@ public class LevelSwap extends Trigger {
     public String levelFilename;
 
     public LevelSwap() { }
+
+    int rotAccumulator = 0;
 
     // triggers can be delayed, fire the actual trigger here
     public void doTriggerEvent(String value) {
@@ -24,8 +27,24 @@ public class LevelSwap extends Trigger {
         try {
             FileHandle levelFile = Game.findInternalFileInMods(levelFilename);
             Level level = LevelSerializer.loadLevel(levelFile);
+
             if (level != null) {
                 Level currentLevel = Game.GetLevel();
+
+                // Rotate the sublevel to match
+                for(int i = 0; i < rotAccumulator; i++) {
+                    level.rotate90();
+                }
+
+                // Offset the tiles vertically
+                for(int i = 0; i < level.tiles.length; i++) {
+                    Tile t = level.tiles[i];
+                    if(t != null) {
+                        t.floorHeight += z;
+                        t.ceilHeight += z;
+                    }
+                }
+
                 currentLevel.paste(level, (int) x - level.width / 2, (int) y - level.height / 2);
 
                 currentLevel.initEntities(level.entities, Level.Source.LEVEL_START);
@@ -38,5 +57,10 @@ public class LevelSwap extends Trigger {
         } catch (Exception ex) {
             Gdx.app.log("LevelSwapTrigger", ex.getMessage());
         }
+    }
+
+    @Override
+    public void rotate90() {
+        rotAccumulator++;
     }
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
@@ -1511,7 +1511,7 @@ public class Level {
 		Game.pathfinding.InitForLevel(this);
 	}
 
-	private void initEntities(Array<Entity> entityList, Source source) {
+	public void initEntities(Array<Entity> entityList, Source source) {
 		if(entityList == null)
 			return;
 


### PR DESCRIPTION
![swap2](https://user-images.githubusercontent.com/1374/51158031-5e8bd100-1837-11e9-9d1a-d2dea7fcecbf.gif)

This could be useful for triggers that raise and lower water levels, destroy chunks of the level, etc!

This works by pasting the tiles of a newly loaded level into the current level, offset by the trigger location.

TODO: Handle rotation, maybe do the chunk update in a thread?