### PR TITLE
Fixing issue where filename was getting assigned to the full path.

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -1997,7 +1997,6 @@ public class EditorApplication implements ApplicationListener {
 
 			FileHandle levelFileHandle = Gdx.files.getFileHandle(fileHandle.file().getAbsolutePath(), Files.FileType.Absolute);
 			if(levelFileHandle.exists()) {
-				currentFileName = levelFileHandle.path();
 				setTitle(currentFileName);
 
 				Level openLevel;


### PR DESCRIPTION
## Summary
Fixes issue with saving an incorrect path. The `currentFileName` was getting set to the full path. When we save we concat the `currentDirectory` and `currentFileName` and get a bad path.