### PR TITLE
DelvEdit Basic Live Reload

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/Art.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/Art.java
@@ -16,9 +16,12 @@ import com.badlogic.gdx.graphics.g3d.loader.ObjLoader;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ArrayMap;
+import com.interrupt.dungeoneer.entities.Entity;
 import com.interrupt.dungeoneer.game.CachePools;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.gfx.Bitmap;
+import com.interrupt.dungeoneer.gfx.GlRenderer;
+import com.interrupt.dungeoneer.gfx.Tesselator;
 import com.interrupt.dungeoneer.gfx.TextureAtlas;
 import com.interrupt.dungeoneer.ui.UiSkin;
 
@@ -204,5 +207,46 @@ public class Art {
 
 		// Might have some pooled meshes to clear
 		CachePools.clearMeshPool();
+	}
+
+	public static void refresh() {
+		try {
+			Art.KillCache();
+
+			Game.instance.loadManagers();
+			GameManager.renderer.initTextures();
+			GameManager.renderer.initShaders();
+
+			GlRenderer.staticMeshPool.resetAndDisposeAllMeshes();
+			Tesselator.tesselatorMeshPool.resetAndDisposeAllMeshes();
+
+			// reset all drawables now that we've reset stuff
+			for (Entity e : Game.GetLevel().entities) {
+				if(e.drawable != null) {
+					e.drawable.refresh();
+					e.drawable.update(e);
+				}
+			}
+			for (Entity e : Game.GetLevel().static_entities) {
+				if(e.drawable != null) {
+					e.drawable.refresh();
+					e.drawable.update(e);
+				}
+			}
+			for (Entity e : Game.GetLevel().non_collidable_entities) {
+				if(e.drawable != null) {
+					e.drawable.refresh();
+					e.drawable.update(e);
+				}
+			}
+
+			GameManager.renderer.setSize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+			Game.GetLevel().isDirty = true;
+
+			UiSkin.loadSkin();
+		}
+		catch(Exception ex) {
+			Gdx.app.log("Delver", "Could not refresh: " + ex.getMessage());
+		}
 	}
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/overlays/DebugOverlay.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/overlays/DebugOverlay.java
@@ -2,7 +2,6 @@ package com.interrupt.dungeoneer.overlays;
 
 import java.util.HashMap;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
@@ -15,16 +14,12 @@ import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Array;
 import com.interrupt.dungeoneer.Art;
-import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.entities.Entity;
 import com.interrupt.dungeoneer.entities.Item;
 import com.interrupt.dungeoneer.entities.Monster;
 import com.interrupt.dungeoneer.entities.Player;
 import com.interrupt.dungeoneer.entities.items.*;
 import com.interrupt.dungeoneer.game.Game;
-import com.interrupt.dungeoneer.gfx.GlRenderer;
-import com.interrupt.dungeoneer.gfx.Tesselator;
-import com.interrupt.dungeoneer.ui.UiSkin;
 import com.interrupt.managers.ItemManager;
 
 public class DebugOverlay extends WindowOverlay {
@@ -357,7 +352,7 @@ public class DebugOverlay extends WindowOverlay {
 			@Override
 			public void clicked(InputEvent event, float x, float y) {
 				OverlayManager.instance.remove(thisOverlay);
-				refreshData();
+				Art.refresh();
 			}
 
 			@Override
@@ -764,47 +759,5 @@ public class DebugOverlay extends WindowOverlay {
 	    buttonOrder.add(doneBtn);
 
 	    return contentTable;
-	}
-
-	// Re-load all the key assets
-	public void refreshData() {
-		try {
-			Art.KillCache();
-
-			Game.instance.loadManagers();
-			GameManager.renderer.initTextures();
-			GameManager.renderer.initShaders();
-
-			GlRenderer.staticMeshPool.resetAndDisposeAllMeshes();
-			Tesselator.tesselatorMeshPool.resetAndDisposeAllMeshes();
-
-			// reset all drawables now that we've reset stuff
-			for (Entity e : Game.GetLevel().entities) {
-				if(e.drawable != null) {
-					e.drawable.refresh();
-					e.drawable.update(e);
-				}
-			}
-			for (Entity e : Game.GetLevel().static_entities) {
-				if(e.drawable != null) {
-					e.drawable.refresh();
-					e.drawable.update(e);
-				}
-			}
-			for (Entity e : Game.GetLevel().non_collidable_entities) {
-				if(e.drawable != null) {
-					e.drawable.refresh();
-					e.drawable.update(e);
-				}
-			}
-
-			GameManager.renderer.setSize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-			Game.GetLevel().isDirty = true;
-
-			UiSkin.loadSkin();
-		}
-		catch(Exception ex) {
-			Gdx.app.log("Delver", "Could not refresh: " + ex.getMessage());
-		}
 	}
 }


### PR DESCRIPTION
![delvedit-filewatcher](https://user-images.githubusercontent.com/372642/80160142-b4464180-8581-11ea-919d-1263941ca2db.gif)
## Summary
Basic implementation of a file watcher that reloads the assets when a change is detected.

## Notes
- The level textures still don't refresh until you enter play mode.
- There is a thread.sleep() in the refresh that is a workaround for Gdx crashing. If there is no sleep, Gdx will complain that it can't find the modified file. This is fragile. 😕