### PR TITLE
Fixing how We Determine a Hitscan Target for Guns

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Gun.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Gun.java
@@ -200,7 +200,7 @@ public class Gun extends Weapon {
             Vector3 hitEntityAt = new Vector3();
 
             Vector3 hitLocation = null;
-            for (int i = 0; i < lvl.entities.size && hit == null; i++) {
+            for (int i = 0; i < lvl.entities.size; i++) {
                 Entity e = lvl.entities.get(i);
                 if (!(e instanceof Sprite || e instanceof Light) && e.isSolid) {
                     testPos.x = e.x;


### PR DESCRIPTION
# Summary
Fixes a bug in which we prefer the first found entity in a hitscan check, rather than the closest entity.