### PR TITLE
Fix player bouncing on spikes

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Spikes.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Spikes.java
@@ -69,14 +69,17 @@ public class Spikes extends Model {
                     hitAlready.add(e);
 
                     if(e instanceof Actor || (!animation.isDonePlaying() && !animation.isReversed())) {
-                        Vector3 dir = getSpikeDirection();
+                        // Do not apply velocity to non-dynamic Entities!
+                        if (e.isDynamic) {
+                            Vector3 dir = getSpikeDirection();
 
-                        float moveAmount = (e instanceof Player) ? 0.04f : 0.03f;
-                        e.xa = dir.x * moveAmount;
-                        e.ya = dir.y * moveAmount;
-                        e.za = dir.z * moveAmount;
+                            float moveAmount = (e instanceof Player) ? 0.04f : 0.03f;
+                            e.xa = dir.x * moveAmount;
+                            e.ya = dir.y * moveAmount;
+                            e.za = dir.z * moveAmount;
 
-                        e.physicsSleeping = false;
+                            e.physicsSleeping = false;
+                        }
                     }
 
                     e.hit(0, 0, 2, 0f, Weapon.DamageType.PHYSICAL, this);


### PR DESCRIPTION
# Summary
Corrects issue where the player would repeatedly bounce on a spike trap. Fixes #53 

Issue involved the Spike object registering a hit against the Model that serves as it's base. On hit the Spikes would give the Model a bit of upward velocity. Because the model by default is a static entity, it would not move or lose it's velocity. Stepping on the Model would then impart the current velocity to the player.