### PR TITLE
Fix Issue with Restore Potion and Invisibility Scroll

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Potion.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Potion.java
@@ -1,23 +1,19 @@
 package com.interrupt.dungeoneer.entities.items;
 
-import java.text.MessageFormat;
-import java.util.Random;
-
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector3;
 import com.interrupt.dungeoneer.Audio;
 import com.interrupt.dungeoneer.annotations.EditorProperty;
-import com.interrupt.dungeoneer.entities.Actor;
-import com.interrupt.dungeoneer.entities.Bomb;
-import com.interrupt.dungeoneer.entities.Entity;
-import com.interrupt.dungeoneer.entities.Item;
-import com.interrupt.dungeoneer.entities.Player;
+import com.interrupt.dungeoneer.entities.*;
 import com.interrupt.dungeoneer.entities.items.Weapon.DamageType;
 import com.interrupt.dungeoneer.game.Colors;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.statuseffects.*;
 import com.interrupt.managers.StringManager;
+
+import java.text.MessageFormat;
+import java.util.Random;
 
 public class Potion extends Item {
 	
@@ -52,9 +48,7 @@ public class Potion extends Item {
 		else if(potionType == PotionType.maxhealth) {
 			displayText = StringManager.get("items.Potion.maxHealDisplayText");
 			player.hp = player.getMaxHp();
-			
-			if(player.statusEffects != null && player.statusEffects.size > 0)
-				player.statusEffects.clear();
+			player.clearStatusEffects();
 		}
 		else if(potionType == PotionType.restore) {
 			player.hp += 1;


### PR DESCRIPTION
# Summary
By using an invisibility scroll and then a restore potion players can make themselves permanently invisible. This was caused by manually clearing the `Actor.statusEffects` array rather than calling `Actor.clearStatusEffects()`.