### PR TITLE
Giving items support to use meshes for their on ground and held modes

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Door.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Door.java
@@ -536,6 +536,9 @@ public class Door extends Entity {
 			drawable.dir.rotate(Vector3.Y, 90f);
 		}
 		else if(doorDirection == DoorDirection.SOUTH) {
+			drawable.dir.rotate(Vector3.Y, 0f);
+		}
+		else if(doorDirection == DoorDirection.NORTH) {
 			drawable.dir.rotate(Vector3.Y, 180f);
 		}
 		else if(doorDirection == DoorDirection.WEST) {
@@ -544,7 +547,7 @@ public class Door extends Entity {
 		
 		if(rot != 0) {
 			if(doorType == DoorType.NORMAL)
-				drawable.dir.rotate(Vector3.Y, rot);
+				drawable.dir.rotate(Vector3.Y, -rot);
 			else if(doorType == DoorType.TRAPDOOR)
 				drawable.dir.rotate(Vector3.X, -rot);
 		}

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Spikes.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Spikes.java
@@ -178,7 +178,6 @@ public class Spikes extends Model {
             drbl.isStaticMesh = false;
             if(drbl.drawOffset == null) drbl.drawOffset = new Vector3();
             drbl.drawOffset.set(getSpikeDirection()).scl(animation.getCurrentPosition().z - 0.5f);
-            drbl.drawOffset.z += yOffset;
 
             drawable.update(this);
         }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/drawables/DrawableMesh.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/drawables/DrawableMesh.java
@@ -32,8 +32,6 @@ public class DrawableMesh extends Drawable {
 	
 	private transient Matrix4 modelView = null;
 	private transient Matrix4 combined = new Matrix4();
-	private transient Matrix4 workspace = new Matrix4();
-	private transient Vector3 workVec = new Vector3();
 
 	public transient Vector3 scaleVector = null;
 	
@@ -54,6 +52,13 @@ public class DrawableMesh extends Drawable {
     public boolean bakeLighting = false;
     private transient Mesh bakedMesh = null;
     private transient Vector3 bakedRotation = new Vector3(0, 0, 0);
+
+    // Scratch work quaternions and vectors
+    private transient Quaternion workQuat1 = new Quaternion();
+    private transient Quaternion workQuat2 = new Quaternion();
+    private transient Vector3 workVec1 = new Vector3();
+    private transient Vector3 workVec2 = new Vector3();
+
 
     public DrawableMesh() { }
 
@@ -139,7 +144,7 @@ public class DrawableMesh extends Drawable {
 	public void update(Entity e) {
 		x = e.x;
 		y = e.y;
-		z = e.z;
+		z = e.z + e.yOffset;
 		fullbrite = e.fullbrite;
 		scale = e.scale;
 		color = e.color;
@@ -157,14 +162,20 @@ public class DrawableMesh extends Drawable {
 		}
 
 		// make the model view
-		Vector3 dirWithoutY = workVec.set(dir.x,0,dir.z);
-		if(modelView == null) modelView = new Matrix4();
-
+		if (modelView == null) modelView = new Matrix4();
 		modelView.setToTranslation(x + drawOffset.x, z - 0.5f + drawOffset.z, y + drawOffset.y);
 
-		modelView.mul(workspace.setToLookAt(dirWithoutY, Vector3.Y));
-		modelView.mul(workspace.setToRotation(Vector3.X, dir.y * -90f));
-			
+		// Rotate to face the direction, this time using Quaternions to support better rotation
+		Vector3 tmp = workVec1.set(Vector3.Y).crs(dir).nor();
+		Vector3 tmp2 = workVec2.set(dir).crs(tmp).nor();
+		workQuat1.setFromAxes(tmp.x, tmp2.x, dir.x, tmp.y, tmp2.y, dir.y, tmp.z, tmp2.z, dir.z);
+
+		// Old way was flipped, new way should also be to not break old stuff
+		workQuat2.set(Vector3.Y, 180f);
+		workQuat1.mul(workQuat2);
+
+		// Apply the quaternion rotation, as well as any other axis based rotation
+		modelView.rotate(workQuat1);
 		modelView.rotate(Vector3.Y, rotZ - bakedRotation.z);
 		modelView.rotate(Vector3.X, rotX - bakedRotation.x);
 		modelView.rotate(Vector3.Z, rotY - bakedRotation.y);


### PR DESCRIPTION
This gives items some new properties:

Group: `Visual - Model`
`meshFile` the mesh to use on the ground, and when held
`viewMeshFile` the mesh to use, only when held. Takes priority over `meshFile`
`textureFile` the texture to use when drawing the mesh

![held-item-1](https://user-images.githubusercontent.com/1374/93435773-c0a79f80-f87e-11ea-93c7-231f53469aa9.gif)
