### PR TITLE
Adding gizmos for projected decal and camera entities

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
-import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
@@ -824,17 +823,11 @@ public class EditorApplication implements ApplicationListener {
 
         Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
 
-		if(Editor.selection.picked instanceof ProjectedDecal) {
-			renderProjection(((ProjectedDecal) Editor.selection.picked).perspective);
-		}
-		else if(Editor.selection.picked instanceof Mover) {
+		if(Editor.selection.picked instanceof Mover) {
 			renderMoverVizualization((Mover) Editor.selection.picked);
 		}
 		for(Entity selectedEntity : Editor.selection.selected) {
-			if(selectedEntity instanceof ProjectedDecal) {
-				renderProjection(((ProjectedDecal)selectedEntity).perspective);
-			}
-			else if(selectedEntity instanceof Mover) {
+			if(selectedEntity instanceof Mover) {
 				renderMoverVizualization((Mover)selectedEntity);
 			}
 		}
@@ -1588,6 +1581,7 @@ public class EditorApplication implements ApplicationListener {
 		}
 		else if(theEntity instanceof ProjectedDecal) {
 			((ProjectedDecal)theEntity).refresh();
+			((ProjectedDecal)theEntity).updateDrawable();
 		}
 		else if(theEntity instanceof Model) {
 			Model m = (Model)theEntity;
@@ -1675,36 +1669,6 @@ public class EditorApplication implements ApplicationListener {
 		lineRenderer.line(e.x - e.collision.x, zStart, e.y - e.collision.y, e.x - e.collision.x, zEnd, e.y - e.collision.y);
 		lineRenderer.line(e.x + e.collision.x, zStart, e.y + e.collision.y, e.x + e.collision.x, zEnd, e.y + e.collision.y);
 		lineRenderer.line(e.x + e.collision.x, zStart, e.y - e.collision.y, e.x + e.collision.x, zEnd, e.y - e.collision.y);
-	}
-
-	public void renderProjection(Camera perspective) {
-		if(perspective == null) return;
-
-		for(int i = 0; i < 4; i++) {
-			Vector3 startPoint = perspective.frustum.planePoints[i];
-			Vector3 endPoint = i != 3 ? perspective.frustum.planePoints[i + 1] : perspective.frustum.planePoints[0];
-
-			lineRenderer.line(startPoint.x, startPoint.y, startPoint.z, endPoint.x, endPoint.y, endPoint.z);
-		}
-
-		for(int i = 0; i < 4; i++) {
-			Vector3 startPoint = perspective.frustum.planePoints[i];
-			Vector3 endPoint = perspective.frustum.planePoints[i + 4];
-
-			lineRenderer.line(startPoint.x, startPoint.y, startPoint.z, endPoint.x, endPoint.y, endPoint.z);
-		}
-
-		for(int i = 4; i < 8; i++) {
-			Vector3 startPoint = perspective.frustum.planePoints[i];
-			Vector3 endPoint = i != 7 ? perspective.frustum.planePoints[i + 1] : perspective.frustum.planePoints[4];
-
-			lineRenderer.line(startPoint.x, startPoint.y, startPoint.z, endPoint.x, endPoint.y, endPoint.z);
-		}
-
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
-		Gdx.gl.glLineWidth(1f);
-		lineRenderer.setColor(Color.CYAN);
-		lineRenderer.flush();
 	}
 
 	public void renderMoverVizualization(Mover e) {

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/gizmos/CameraGizmo.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/gizmos/CameraGizmo.java
@@ -1,0 +1,17 @@
+package com.interrupt.dungeoneer.editor.gizmos;
+
+import com.badlogic.gdx.math.Frustum;
+import com.interrupt.dungeoneer.editor.ui.Handles;
+import com.interrupt.dungeoneer.entities.Camera;
+import com.interrupt.dungeoneer.entities.Entity;
+
+@GizmoFor(target = Camera.class)
+public class CameraGizmo extends EntityGizmo {
+    @Override
+    public void draw(Entity entity) {
+        super.draw(entity);
+        Camera camera = (Camera) entity;
+        Frustum frustum = camera.getCamera().frustum;
+        Handles.drawWireFrustum(frustum);
+    }
+}

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/gizmos/ProjectedDecalGizmo.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/gizmos/ProjectedDecalGizmo.java
@@ -1,0 +1,25 @@
+package com.interrupt.dungeoneer.editor.gizmos;
+
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.math.Frustum;
+import com.interrupt.dungeoneer.editor.ui.Handles;
+import com.interrupt.dungeoneer.entities.Entity;
+import com.interrupt.dungeoneer.entities.ProjectedDecal;
+
+@GizmoFor(target = ProjectedDecal.class)
+public class ProjectedDecalGizmo extends EntityGizmo {
+    @Override
+    public void draw(Entity entity) {
+        super.draw(entity);
+
+        ProjectedDecal decal = (ProjectedDecal) entity;
+        Camera camera = decal.perspective;
+
+        if (camera == null) {
+            return;
+        }
+
+        Frustum frustum = camera.frustum;
+        Handles.drawWireFrustum(frustum);
+    }
+}

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/Handles.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/Handles.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Frustum;
 import com.badlogic.gdx.math.Vector3;
 import com.interrupt.dungeoneer.editor.Editor;
 
@@ -32,6 +33,12 @@ public class Handles {
     public static void drawWireCube(Vector3 position, Vector3 size) {
         begin();
         drawWireCubeInternal(position, size);
+        end();
+    }
+
+    public static void drawWireFrustum(Frustum frustum) {
+        begin();
+        drawWireFrustumInternal(frustum);
         end();
     }
 
@@ -146,5 +153,28 @@ public class Handles {
         renderer.line(p1, p5);
         renderer.line(p2, p6);
         renderer.line(p3, p7);
+    }
+
+    private static void drawWireFrustumInternal(Frustum frustum) {
+        for(int i = 0; i < 4; i++) {
+			Vector3 startPoint = frustum.planePoints[i];
+			Vector3 endPoint = i != 3 ? frustum.planePoints[i + 1] : frustum.planePoints[0];
+
+			renderer.line(startPoint.x, startPoint.y, startPoint.z, endPoint.x, endPoint.y, endPoint.z);
+		}
+
+		for(int i = 0; i < 4; i++) {
+			Vector3 startPoint = frustum.planePoints[i];
+			Vector3 endPoint = frustum.planePoints[i + 4];
+
+			renderer.line(startPoint.x, startPoint.y, startPoint.z, endPoint.x, endPoint.y, endPoint.z);
+		}
+
+		for(int i = 4; i < 8; i++) {
+			Vector3 startPoint = frustum.planePoints[i];
+			Vector3 endPoint = i != 7 ? frustum.planePoints[i + 1] : frustum.planePoints[4];
+
+			renderer.line(startPoint.x, startPoint.y, startPoint.z, endPoint.x, endPoint.y, endPoint.z);
+		}
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/372642/93795729-a5c28b80-fbee-11ea-9bdf-d28b751fcdbc.png)

# Summary
Adding gizmos for ProjectedDecal and Camera entities. ProjectedDecals visualizations were being drawn in `EditorApplication.draw()` but I've refactored them to use the Gizmo system. 