### PR TITLE
Hiding Selection Outline When Out-Of-Bounds

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -747,31 +747,11 @@ public class EditorApplication implements ApplicationListener {
 				end = ray.getEndPoint(rayOutVector, distance + 0.005f);
 
 				// Tile selection bounding
-				boolean isOutOfBounds = false;
-				Editor.selection.tiles.x = (int)end.x;
-				Editor.selection.tiles.y = (int)end.z;
-
-				if(Editor.selection.tiles.x < 0) {
-					Editor.selection.tiles.x = 0;
-					isOutOfBounds = true;
-				}
-				if(Editor.selection.tiles.x >= level.width) {
-					Editor.selection.tiles.x = level.width - 1;
-					isOutOfBounds = true;
-				}
-
-				if(Editor.selection.tiles.y < 0) {
-					Editor.selection.tiles.y = 0;
-					isOutOfBounds = true;
-				}
-				if(Editor.selection.tiles.y >= level.height) {
-					Editor.selection.tiles.y = level.height - 1;
-					isOutOfBounds = true;
-				}
-
+				Editor.selection.tiles.clear((int)end.x, (int)end.z);
+				boolean isOutOfBounds = Editor.selection.tiles.outOfLevelBounds(level.width, level.height);
+				Editor.selection.tiles.cropToLevelBounds(level.width, level.height);
 				shouldDrawBox = isOutOfBounds ? false : shouldDrawBox;
 
-                Editor.selection.tiles.width = Editor.selection.tiles.height = 1;
 				selStartX = Editor.selection.tiles.x;
 				selStartY = Editor.selection.tiles.y;
 				controlPoints.clear();

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -736,15 +736,30 @@ public class EditorApplication implements ApplicationListener {
 
 				end = ray.getEndPoint(rayOutVector, distance + 0.005f);
 
-						// Tile selection bounding
+				// Tile selection bounding
+				boolean isOutOfBounds = false;
 				Editor.selection.tiles.x = (int)end.x;
 				Editor.selection.tiles.y = (int)end.z;
 
-				if(Editor.selection.tiles.x < 0) Editor.selection.tiles.x = 0;
-				if(Editor.selection.tiles.x >= level.width) Editor.selection.tiles.x = level.width - 1;
+				if(Editor.selection.tiles.x < 0) {
+					Editor.selection.tiles.x = 0;
+					isOutOfBounds = true;
+				}
+				if(Editor.selection.tiles.x >= level.width) {
+					Editor.selection.tiles.x = level.width - 1;
+					isOutOfBounds = true;
+				}
 
-				if(Editor.selection.tiles.y < 0) Editor.selection.tiles.y = 0;
-				if(Editor.selection.tiles.y >= level.height) Editor.selection.tiles.y = level.height - 1;
+				if(Editor.selection.tiles.y < 0) {
+					Editor.selection.tiles.y = 0;
+					isOutOfBounds = true;
+				}
+				if(Editor.selection.tiles.y >= level.height) {
+					Editor.selection.tiles.y = level.height - 1;
+					isOutOfBounds = true;
+				}
+
+				shouldDrawBox = isOutOfBounds ? false : shouldDrawBox;
 
                 Editor.selection.tiles.width = Editor.selection.tiles.height = 1;
 				selStartX = Editor.selection.tiles.x;

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -35,6 +35,7 @@ import com.interrupt.dungeoneer.editor.gizmos.Gizmo;
 import com.interrupt.dungeoneer.editor.gizmos.GizmoProvider;
 import com.interrupt.dungeoneer.editor.history.EditorHistory;
 import com.interrupt.dungeoneer.editor.selection.AdjacentTileSelectionInfo;
+import com.interrupt.dungeoneer.editor.selection.TileSelection;
 import com.interrupt.dungeoneer.editor.selection.TileSelectionInfo;
 import com.interrupt.dungeoneer.editor.ui.EditorUi;
 import com.interrupt.dungeoneer.editor.ui.SaveChangesDialog;
@@ -317,6 +318,8 @@ public class EditorApplication implements ApplicationListener {
 
 	private LiveReload liveReload;
 
+	private TileSelection entireLevelSelection;
+
 	public EditorApplication() {
 		frame = new JFrame("DelvEdit");
 
@@ -413,6 +416,7 @@ public class EditorApplication implements ApplicationListener {
 
 	public void createEmptyLevel(int width, int height) {
 		level = new Level(width, height);
+		entireLevelSelection = TileSelection.Rect(0, 0, level.width, level.height);
 		refresh();
 		
 		history = new EditorHistory();
@@ -747,10 +751,9 @@ public class EditorApplication implements ApplicationListener {
 				end = ray.getEndPoint(rayOutVector, distance + 0.005f);
 
 				// Tile selection bounding
-				Editor.selection.tiles.clear((int)end.x, (int)end.z);
-				boolean isOutOfBounds = Editor.selection.tiles.outOfLevelBounds(level.width, level.height);
-				Editor.selection.tiles.cropToLevelBounds(level.width, level.height);
-				shouldDrawBox = isOutOfBounds ? false : shouldDrawBox;
+				Editor.selection.tiles.x = Math.min(level.width - 1, Math.max(0, (int)end.x));
+				Editor.selection.tiles.y = Math.min(level.height - 1, Math.max(0, (int)end.z));
+				shouldDrawBox &= entireLevelSelection.contains((int)end.x, (int)end.z);
 
 				selStartX = Editor.selection.tiles.x;
 				selStartY = Editor.selection.tiles.y;

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/selection/TileSelection.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/selection/TileSelection.java
@@ -99,8 +99,8 @@ public class TileSelection implements Iterable<TileSelectionInfo>{
 
     /** Crops the selection to only contain level in-bounds tiles. */
     public void cropToLevelBounds(int width, int height) {
-        x = Math.min(width, Math.max(0, x));
-        y = Math.min(height, Math.max(0, y));
+        x = Math.min(width - 1, Math.max(0, x));
+        y = Math.min(height - 1, Math.max(0, y));
     }
 
     private final Array<TileSelectionInfo> tileInfos = new Array<TileSelectionInfo>();

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/selection/TileSelection.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/selection/TileSelection.java
@@ -70,9 +70,15 @@ public class TileSelection implements Iterable<TileSelectionInfo>{
         };
     }
 
+    /** Clear the tile selection and reset the origin to (0, 0). */
     public void clear() {
-        x = 0;
-        y = 0;
+        clear(0, 0);
+    }
+
+    /** Clear the tile selection and set the origin explicitly. */
+    public void clear(int x, int y) {
+        this.x = x;
+        this.y = y;
         width = 1;
         height = 1;
     }
@@ -84,6 +90,17 @@ public class TileSelection implements Iterable<TileSelectionInfo>{
 
     public boolean contains(int x, int y) {
          return x >= this.x && x < this.x + width && y >= this.y && y < this.y + height;
+    }
+
+    /** Returns whether the tile selection contains level out-of-bounds tiles. */
+    public boolean outOfLevelBounds(int width, int height) {
+        return (x < 0 || x >= width || y < 0 || y >= height) ? true: false;
+    }
+
+    /** Crops the selection to only contain level in-bounds tiles. */
+    public void cropToLevelBounds(int width, int height) {
+        x = Math.min(width, Math.max(0, x));
+        y = Math.min(height, Math.max(0, y));
     }
 
     private final Array<TileSelectionInfo> tileInfos = new Array<TileSelectionInfo>();

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/selection/TileSelection.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/selection/TileSelection.java
@@ -70,15 +70,20 @@ public class TileSelection implements Iterable<TileSelectionInfo>{
         };
     }
 
-    /** Clear the tile selection and reset the origin to (0, 0). */
-    public void clear() {
-        clear(0, 0);
+    public static TileSelection Rect(int x, int y, int width, int height) {
+        TileSelection tileSelection = new TileSelection();
+
+        tileSelection.x = x;
+        tileSelection.y = y;
+        tileSelection.width = width;
+        tileSelection.height = height;
+
+        return tileSelection;
     }
 
-    /** Clear the tile selection and set the origin explicitly. */
-    public void clear(int x, int y) {
-        this.x = x;
-        this.y = y;
+    public void clear() {
+        x = 0;
+        y = 0;
         width = 1;
         height = 1;
     }
@@ -90,17 +95,6 @@ public class TileSelection implements Iterable<TileSelectionInfo>{
 
     public boolean contains(int x, int y) {
          return x >= this.x && x < this.x + width && y >= this.y && y < this.y + height;
-    }
-
-    /** Returns whether the tile selection contains level out-of-bounds tiles. */
-    public boolean outOfLevelBounds(int width, int height) {
-        return (x < 0 || x >= width || y < 0 || y >= height) ? true: false;
-    }
-
-    /** Crops the selection to only contain level in-bounds tiles. */
-    public void cropToLevelBounds(int width, int height) {
-        x = Math.min(width - 1, Math.max(0, x));
-        y = Math.min(height - 1, Math.max(0, y));
     }
 
     private final Array<TileSelectionInfo> tileInfos = new Array<TileSelectionInfo>();


### PR DESCRIPTION
## Summary
Fixes #84. Hides the selection outline when hovering over a tile that is out-of-bounds. That also includes when hovering over the menu bar. Left clicking is not affected and will still select the nearest tile.

![issue-84-fix](https://user-images.githubusercontent.com/13063023/93993551-2ae4a680-fd8f-11ea-9d57-96b12863f562.gif)
