### PR TITLE
Hiding Selection Box For Open Modal

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -725,6 +725,8 @@ public class EditorApplication implements ApplicationListener {
 			shouldDrawBox = false;
 		}
 
+		shouldDrawBox = ui.isShowingModal() ? false : shouldDrawBox;
+
 		if(Editor.selection.picked == null && Editor.selection.hovered == null || tileDragging) {
 			if(!selected || (!(pickedControlPoint != null || movingControlPoint) &&
                     editorInput.isButtonPressed(Input.Buttons.LEFT) && Gdx.input.justTouched())) {


### PR DESCRIPTION
## Summary
Fixes #81. Hides the selection outline when having a modal open (e.g. saving/loading).

The entire logic should better be refactored, this PR just fixes the immediate issue.

![issue-81-fix](https://user-images.githubusercontent.com/13063023/93999811-954d1500-fd96-11ea-8ab2-5a16223cb581.gif)
