### PR TITLE
Restructuring New Level Generation

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -419,11 +419,11 @@ public class EditorApplication implements ApplicationListener {
 		file = new EditorFile();
 		
 		Tile t = new Tile();
-        t.floorHeight = -0.5f;
+		t.floorHeight = -0.5f;
 		t.ceilHeight = 0.5f;
-        level.setTile(width / 2, height / 2, t);
+		level.setTile(width / 2, height / 2, t);
 
-        history.saveState(level);
+		history.saveState(level);
 		file.markClean();
 
 		cameraController.setDefaultPositionAndRotation();

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -408,18 +408,27 @@ public class EditorApplication implements ApplicationListener {
         pickedWallTextureAtlas = pickedWallBottomTextureAtlas = pickedFloorTextureAtlas = pickedCeilingTextureAtlas =
                 TextureAtlas.cachedRepeatingAtlases.firstKey();
 
-        level = new Level(17,17);
-        Tile t = new Tile();
+		createEmptyLevel(17, 17);
+	}
+
+	public void createEmptyLevel(int width, int height) {
+		level = new Level(width, height);
+		refresh();
+		
+		history = new EditorHistory();
+		file = new EditorFile();
+		
+		Tile t = new Tile();
         t.floorHeight = -0.5f;
-        t.ceilHeight = 0.5f;
-        level.setTile(7, 7, t);
+		t.ceilHeight = 0.5f;
+		int xPosition = width / 2;
+		int yPosition = height / 2;
+        level.setTile(xPosition, yPosition, t);
 
-        history = new EditorHistory();
-        file = new EditorFile();
-        history.saveState(Editor.app.level);
-        file.markClean();
+        history.saveState(level);
+		file.markClean();
 
-        gridMesh = genGrid(level.width,level.height);
+		cameraController.setDefaultPositionAndRotation();
 	}
 
 	@Override
@@ -2625,10 +2634,10 @@ public class EditorApplication implements ApplicationListener {
     }
 
 	public void refresh() {
-		gridMesh.dispose();
+		if (gridMesh != null) gridMesh.dispose();
 		gridMesh = null;
 
-		gridMesh = genGrid(level.width,level.height);
+		gridMesh = genGrid(level.width, level.height);
 
 		refreshLights();
 	}

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -421,9 +421,7 @@ public class EditorApplication implements ApplicationListener {
 		Tile t = new Tile();
         t.floorHeight = -0.5f;
 		t.ceilHeight = 0.5f;
-		int xPosition = width / 2;
-		int yPosition = height / 2;
-        level.setTile(xPosition, yPosition, t);
+        level.setTile(width / 2, height / 2, t);
 
         history.saveState(level);
 		file.markClean();
@@ -2634,8 +2632,10 @@ public class EditorApplication implements ApplicationListener {
     }
 
 	public void refresh() {
-		if (gridMesh != null) gridMesh.dispose();
-		gridMesh = null;
+		if (gridMesh != null) {
+			gridMesh.dispose();
+			gridMesh = null;
+		}
 
 		gridMesh = genGrid(level.width, level.height);
 

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorCameraController.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorCameraController.java
@@ -278,6 +278,6 @@ public class EditorCameraController extends InputAdapter implements EditorSubsys
         float position = projectedDistance / 1.4142f;
 
         setPosition(position + width / 2, position + height / 2, altitude);
-		setRotation((float)Math.PI + (float)Math.PI / 4f, lookAngle);
+        setRotation((float)Math.PI + (float)Math.PI / 4f, lookAngle);
     }
 }

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorCameraController.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorCameraController.java
@@ -264,4 +264,20 @@ public class EditorCameraController extends InputAdapter implements EditorSubsys
                 InterpolationHelper.InterpolationMode.exp10Out
         );
     }
+
+    public void setDefaultPositionAndRotation() {
+        Level level = Editor.app.level;
+        int width = level.width;
+        int height = level.height;
+
+        float altitude = 6f;
+        float distance = 10f;
+
+        float lookAngle = (float)Math.asin((float)altitude/distance);
+        float projectedDistance = distance * (float)Math.cos((float)lookAngle);
+        float position = projectedDistance / 1.4142f;
+
+        setPosition(position + width / 2, position + height / 2, altitude);
+		setRotation((float)Math.PI + (float)Math.PI / 4f, lookAngle);
+    }
 }

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
@@ -349,21 +349,7 @@ public class EditorFile {
     }
 
     private void createInternal(int width, int height) {
-        Editor.app.history = new EditorHistory();
-        Editor.app.file = new EditorFile();
-
-        Editor.app.level = new Level(width,height);
-        Editor.app.refresh();
-
-        Editor.app.history.saveState(Editor.app.level);
-        Editor.app.file.markClean();
-
-        Editor.app.cameraController.setPosition(
-                Editor.app.level.width / 2f,
-                Editor.app.level.height / 2f,
-                4.5f
-        );
-        Editor.app.viewSelected();
+        Editor.app.createEmptyLevel(width, height);
     }
 
     public long getMillisSinceLastSave() {


### PR DESCRIPTION
## Summary
Fixes #89. Makes sure that new level generation behavior stays consistent both on startup and on menu option. Configurable (hard-coded) options are the camera altitude and distance to the center. I just chose some sensible defaults here.

Startup (17x17):
![grafik](https://user-images.githubusercontent.com/13063023/94036575-baf11300-fdc4-11ea-9336-089afcf32df0.png)

Menu Option (10x10):
![grafik](https://user-images.githubusercontent.com/13063023/94036630-cba18900-fdc4-11ea-8bfe-20a9b783b144.png)
