### PR TITLE
Adjusting emissive calculation on main shader

### DIFF
--- a/Dungeoneer/assets/shaders/animate.frag
+++ b/Dungeoneer/assets/shaders/animate.frag
@@ -16,9 +16,9 @@ varying vec2 v_texCoords;
 varying float v_fogFactor;
 varying float v_eyeDistance;
 
-void main() {
-    float epsilon = 1.0 / 256.0;
+const float epsilon = 1.0 / 256.0;
 
+void main() {
     vec4 tex_Color = texture2D(u_texture, v_texCoords);
     if(tex_Color.a < epsilon) discard;
 

--- a/Dungeoneer/assets/shaders/animate.frag
+++ b/Dungeoneer/assets/shaders/animate.frag
@@ -16,17 +16,15 @@ varying vec2 v_texCoords;
 varying float v_fogFactor;
 varying float v_eyeDistance;
 
-vec4 tex_Color;
-
 void main() {
-  vec4 color;
+    float epsilon = 1.0 / 256.0;
 
-  tex_Color = texture2D( u_texture, v_texCoords );
-  color = v_color * tex_Color;
-  if(tex_Color.a < 0.01) discard;
+    vec4 tex_Color = texture2D(u_texture, v_texCoords);
+    if(tex_Color.a < epsilon) discard;
 
-  // Pack emissive into the alpha channel
-  color += tex_Color * (1.0 - tex_Color.a) * 2.5;
+    // Alpha channel drives emissive/fullbrite
+    vec4 fullbrite = tex_Color / (tex_Color.a);
+    vec4 color = mix(fullbrite, tex_Color * v_color, tex_Color.a);
 
-  gl_FragColor = mix(u_FogColor, color, v_fogFactor);
+    gl_FragColor = mix(u_FogColor, color, v_fogFactor);
 }

--- a/Dungeoneer/assets/shaders/animate.frag
+++ b/Dungeoneer/assets/shaders/animate.frag
@@ -16,11 +16,11 @@ varying vec2 v_texCoords;
 varying float v_fogFactor;
 varying float v_eyeDistance;
 
-const float epsilon = 1.0 / 256.0;
+const float c_epsilon = 1.0 / 256.0;
 
 void main() {
     vec4 tex_Color = texture2D(u_texture, v_texCoords);
-    if(tex_Color.a < epsilon) discard;
+    if(tex_Color.a < c_epsilon) discard;
 
     // Alpha channel drives emissive/fullbrite
     vec4 fullbrite = tex_Color / (tex_Color.a);

--- a/Dungeoneer/assets/shaders/main.frag
+++ b/Dungeoneer/assets/shaders/main.frag
@@ -11,11 +11,11 @@ varying vec2 v_texCoords;
 varying float v_fogFactor;
 varying float v_eyeDistance;
 
-const float epsilon = 1.0 / 256.0;
+const float c_epsilon = 1.0 / 256.0;
 
 void main() {
     vec4 tex_Color = texture2D(u_texture, v_texCoords);
-    if(tex_Color.a < epsilon) discard;
+    if(tex_Color.a < c_epsilon) discard;
 
     // Alpha channel drives emissive/fullbrite
     vec4 fullbrite = tex_Color / (tex_Color.a);

--- a/Dungeoneer/assets/shaders/main.frag
+++ b/Dungeoneer/assets/shaders/main.frag
@@ -11,17 +11,15 @@ varying vec2 v_texCoords;
 varying float v_fogFactor;
 varying float v_eyeDistance;
 
-vec4 tex_Color;
-
 void main() {
-  vec4 color;
-    
-  tex_Color = texture2D( u_texture, v_texCoords );
-  color = v_color * tex_Color;
-  if(tex_Color.a < 0.01) discard;
+    float epsilon = 1.0 / 256.0;
 
-  // Pack emissive into the alpha channel
-  color += tex_Color * (1.0 - tex_Color.a) * 2.5;
+    vec4 tex_Color = texture2D(u_texture, v_texCoords);
+    if(tex_Color.a < epsilon) discard;
 
-  gl_FragColor = mix(u_FogColor, color, v_fogFactor);
+    // Alpha channel drives emissive/fullbrite
+    vec4 fullbrite = tex_Color / (tex_Color.a);
+    vec4 color = mix(fullbrite, tex_Color * v_color, tex_Color.a);
+
+    gl_FragColor = mix(u_FogColor, color, v_fogFactor);
 }

--- a/Dungeoneer/assets/shaders/main.frag
+++ b/Dungeoneer/assets/shaders/main.frag
@@ -11,9 +11,9 @@ varying vec2 v_texCoords;
 varying float v_fogFactor;
 varying float v_eyeDistance;
 
-void main() {
-    float epsilon = 1.0 / 256.0;
+const float epsilon = 1.0 / 256.0;
 
+void main() {
     vec4 tex_Color = texture2D(u_texture, v_texCoords);
     if(tex_Color.a < epsilon) discard;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/372642/94072808-3fcf3300-fdab-11ea-919f-cda360ba2098.png)
_Linear alpha gradient applied across center texture. Left current. Right proposed._

# Summary
The crux of this fix is to divide out the premultiplied alpha:
```glsl
vec4 fullbrite = tex_Color / (tex_Color.a);
```
This does have the side effect of imprecise colors with low color values when the alpha is close to zero.