### PR TITLE
Fix #91

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -495,7 +495,7 @@ public class EditorApplication implements ApplicationListener {
 				float z = Game.instance.player.z + Game.instance.player.eyeHeight;
 				float y = Game.instance.player.y;
 
-				float rotationX = Game.instance.player.rot + 3.14159265f;
+				float rotationX = Game.instance.player.rot;
 				float rotationY = -Game.instance.player.yrot;
 
 				cameraController.setPosition(x, y, z);
@@ -525,6 +525,7 @@ public class EditorApplication implements ApplicationListener {
         if(stage != null) {
             stage.act(Gdx.graphics.getDeltaTime());
             stage.draw();
+
         }
 	}
 

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -2160,7 +2160,7 @@ public class EditorApplication implements ApplicationListener {
 		Game.instance.player.x = cameraPosition.x;
 		Game.instance.player.y = cameraPosition.y - Game.instance.player.eyeHeight;
 		Game.instance.player.z = cameraPosition.z;
-		Game.instance.player.rot = cameraRotation.x - 3.14159265f;
+		Game.instance.player.rot = cameraRotation.x;
 		Game.instance.player.yrot = -cameraRotation.y;
 		Game.isDebugMode = true;
 	}


### PR DESCRIPTION
Because the rotation was 'corrected' in the EditorCameraController refactor effort, the rotationX was incorrectly offset by 180 degrees.

Removing that offset makes the behaviour correct again, and fixes #91.