### PR TITLE
Fixing FilePicker Path Issue

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/FilePicker.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/FilePicker.java
@@ -16,6 +16,7 @@ import com.interrupt.dungeoneer.editor.ui.menu.FileListItem;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
@@ -285,7 +286,14 @@ public class FilePicker extends Dialog {
         }
 
         this.stage = stage;
-        changeDirectory(new FileHandle(baseDir.file().getAbsoluteFile()));
+
+        File file = null;
+        try {
+            file = baseDir.file().getCanonicalFile();
+        } catch (IOException e) {
+            file = baseDir.file().getAbsoluteFile();
+        }
+        changeDirectory(new FileHandle(file));
 
         return super.show(stage);
     }


### PR DESCRIPTION
## Summary
Fixes #77. Using the canonical path instead of the unnormalized absolute path of the current path.

![grafik](https://user-images.githubusercontent.com/13063023/94350875-1df7d980-0053-11eb-8d3c-e40befcda9c3.png)
