### PR TITLE
Fixing FileList Not Scrollable At Start

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/FilePicker.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/FilePicker.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField.TextFieldListener;
@@ -238,7 +239,18 @@ public class FilePicker extends Dialog {
     public Dialog show(Stage stage) {
         final Table content = getContentTable();
         content.add(fileListLabel).colspan(2).top().left().expandX().fillX().row();
+
         ScrollPane pane = new ScrollPane(fileList, skin);
+        pane.addListener(new InputListener() {
+            public void enter(InputEvent event, float x, float y, int pointer, Actor fromActor) {
+                getStage().setScrollFocus(fromActor);
+            }
+
+            public void exit(InputEvent event, float x, float y, int pointer, Actor toActor) {
+                getStage().setScrollFocus(null);
+            }
+        });
+
         content.add(pane).size(300, 350).colspan(2).fill().expand().row();
 
         if (fileNameEnabled) {


### PR DESCRIPTION
![issue-78-fix](https://user-images.githubusercontent.com/13063023/94351183-97dd9200-0056-11eb-922c-2acbb7bb4806.gif)

## Summary
Fixes #78. Fixing that the FileList is not scrollable at start, but needs first to be focused. Now, the user can start scrolling with the mouse wheel immediately.