### PR TITLE
Make Legacy Level Format In Load Dialog Optional

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
@@ -223,14 +223,23 @@ public class EditorFile {
     }
 
     private void promptOpenFile() {
-        class WSFilter implements FileFilter {
+        class DefaultFileFilter implements FileFilter {
+            @Override
+            public boolean accept(File path) {
+                String name = path.getName();
+                return (name.endsWith(".dat") || name.endsWith(".bin"));
+            }
+        }
+        FileFilter defaultFileFilter = new DefaultFileFilter();
+
+        class LegacyFileFilter implements FileFilter {
             @Override
             public boolean accept(File path) {
                 String name = path.getName();
                 return (name.endsWith(".dat") || name.endsWith(".png") || name.endsWith(".bin"));
             }
         }
-        FileFilter wsFilter = new WSFilter();
+        FileFilter legacyFileFilter = new LegacyFileFilter();
 
         if(Editor.app.file.directory() == null) {
             Editor.app.file = new EditorFile(new FileHandle("."));
@@ -240,7 +249,8 @@ public class EditorFile {
         picker.setFileNameEnabled(true);
         picker.setNewFolderEnabled(false);
         if(Editor.app.file.name() != null) picker.setFileName(Editor.app.file.name());
-        picker.setFilter(wsFilter);
+        picker.setFilter(defaultFileFilter);
+        picker.enableLegacyFormatDisplayToggle(defaultFileFilter, legacyFileFilter);
 
         picker.setResultListener(new FilePicker.ResultListener() {
             @Override

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
@@ -227,8 +227,7 @@ public class EditorFile {
         class DefaultFileFilter implements FileFilter {
             @Override
             public boolean accept(File path) {
-                String name = path.getName();
-                return (name.endsWith(".dat") || name.endsWith(".bin"));
+                return hasValidLoadableExtension(path.getName());
             }
         }
         FileFilter defaultFileFilter = new DefaultFileFilter();
@@ -236,7 +235,8 @@ public class EditorFile {
         class LegacyFileFilter implements FileFilter {
             @Override
             public boolean accept(File path) {
-                return hasValidLoadableExtension(path.getName());
+                String name = path.getName();
+                return (hasValidLoadableExtension(name) || hasValidLoadableLegacyExtension(name));
             }
         }
         FileFilter legacyFileFilter = new LegacyFileFilter();
@@ -375,7 +375,11 @@ public class EditorFile {
     }
 
     private boolean hasValidLoadableExtension(String fileName) {
-        return (fileName.endsWith(".dat") || fileName.endsWith(".bin") || fileName.endsWith(".png"));
+        return (fileName.endsWith(".dat") || fileName.endsWith(".bin"));
+    }
+
+    private boolean hasValidLoadableLegacyExtension(String fileName) {
+        return fileName.endsWith(".png");
     }
 
     public long getMillisSinceLastSave() {

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/FilePicker.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/FilePicker.java
@@ -31,12 +31,16 @@ public class FilePicker extends Dialog {
     private final Skin skin;
     private boolean fileNameEnabled;
     private boolean newFolderEnabled;
+    private boolean directoryBrowsingEnabled = true;
+    private boolean legacyFormatDisplayToggleEnabled;
     private final TextField fileNameInput;
     private final Label fileNameLabel;
     private final TextButton newFolderButton;
     protected final FileHandle baseDir;
     private final Label fileListLabel;
     private final List fileList;
+    private final CheckBox legacyFormatDisplayToggle;
+    private ChangeListener legacyFormatDisplayToggleChangeListener;
 
     private FileHandle currentDir;
     protected String result;
@@ -63,13 +67,14 @@ public class FilePicker extends Dialog {
             return 1;
         }
     };
-    private FileFilter filter = new FileFilter() {
+
+    private final FileFilter defaultFilter = new FileFilter() {
         @Override
         public boolean accept(File pathname) {
             return true;
         }
     };
-    private boolean directoryBrowsingEnabled = true ;
+    private FileFilter filter = defaultFilter;
 
     public FilePicker(String title, final Skin skin, FileHandle baseDir) {
         super(title, skin);
@@ -95,6 +100,8 @@ public class FilePicker extends Dialog {
                 result = textField.getText();
             }
         });
+
+        legacyFormatDisplayToggle = new CheckBox("Display legacy formats", skin);
 
         newFolderButton = new TextButton("New Folder", skin);
 
@@ -151,7 +158,6 @@ public class FilePicker extends Dialog {
     }
 
     private void changeDirectory(FileHandle directory) {
-
         currentDir = directory;
         String title = currentDir.path();
         if (title.length() > 38) title = "..." + title.substring(title.length() - 38, title.length());
@@ -235,6 +241,35 @@ public class FilePicker extends Dialog {
         return this;
     }
 
+    public FilePicker enableLegacyFormatDisplayToggle(final FileFilter defaultFileFilter, final FileFilter legacyFileFilter) {
+        legacyFormatDisplayToggleEnabled = true;
+
+        if (legacyFormatDisplayToggleChangeListener != null) {
+            legacyFormatDisplayToggle.removeListener(legacyFormatDisplayToggleChangeListener);
+        }
+
+        legacyFormatDisplayToggleChangeListener = new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                filter = legacyFormatDisplayToggle.isChecked() ? legacyFileFilter : defaultFileFilter;
+                changeDirectory(currentDir);
+            }
+        };
+
+        legacyFormatDisplayToggle.addListener(legacyFormatDisplayToggleChangeListener);
+
+        return this;
+    }
+
+    public FilePicker disableLegacyFormatDisplayToggle() {
+        legacyFormatDisplayToggleEnabled = false;
+
+        if (legacyFormatDisplayToggleChangeListener != null) {
+            legacyFormatDisplayToggle.removeListener(legacyFormatDisplayToggleChangeListener);
+        }
+
+        return this;
+    }
 
     @Override
     public Dialog show(Stage stage) {
@@ -253,6 +288,10 @@ public class FilePicker extends Dialog {
         });
 
         content.add(pane).size(300, 350).colspan(2).fill().expand().row();
+
+        if (legacyFormatDisplayToggleEnabled) {
+            content.add(legacyFormatDisplayToggle).left().colspan(2).row();
+        }
 
         if (fileNameEnabled) {
             content.add(fileNameLabel);

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/FilePicker.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/FilePicker.java
@@ -246,6 +246,7 @@ public class FilePicker extends Dialog {
 
         if (legacyFormatDisplayToggleChangeListener != null) {
             legacyFormatDisplayToggle.removeListener(legacyFormatDisplayToggleChangeListener);
+            legacyFormatDisplayToggleChangeListener = null;
         }
 
         legacyFormatDisplayToggleChangeListener = new ChangeListener() {
@@ -266,6 +267,7 @@ public class FilePicker extends Dialog {
 
         if (legacyFormatDisplayToggleChangeListener != null) {
             legacyFormatDisplayToggle.removeListener(legacyFormatDisplayToggleChangeListener);
+            legacyFormatDisplayToggleChangeListener = null;
         }
 
         return this;


### PR DESCRIPTION
![issue-80-fix](https://user-images.githubusercontent.com/13063023/94527799-d2eaeb80-0237-11eb-9a17-c9b6363ec4c7.gif)

## Summary

Fixes #80. Adds a new checkbox to the `FilePicker` interface that lets the user toggle between normal/legacy file display. Meaning, that `.png` files are now hidden by default.
