### PR TITLE
Replace T-key rotation in the editor with ActionListeners

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorActions.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorActions.java
@@ -49,6 +49,8 @@ public class EditorActions {
     public ActionListener yDragMode;
     public ActionListener zDragMode;
     public ActionListener rotateMode;
+    public ActionListener turnLeftAction;
+    public ActionListener turnRightAction;
     public ActionListener flattenFloor;
     public ActionListener flattenCeiling;
     public ActionListener toggleSimulation;
@@ -67,19 +69,19 @@ public class EditorActions {
 
         saveAction = new ActionListener() {
             @Override
-            public void actionPerformed (ActionEvent event) {
+            public void actionPerformed(ActionEvent event) {
                 Editor.app.file.save();
             }
         };
 
         saveAsAction = new ActionListener() {
-            public void actionPerformed (ActionEvent event) {
+            public void actionPerformed(ActionEvent event) {
                 Editor.app.file.saveAs(new SaveAdapter());
             }
         };
 
         openAction = new ActionListener() {
-            public void actionPerformed (ActionEvent event) {
+            public void actionPerformed(ActionEvent event) {
                 Editor.app.file.open();
             }
         };
@@ -338,22 +340,43 @@ public class EditorActions {
 
         xDragMode = new ActionListener() {
             @Override
-            public void actionPerformed(ActionEvent actionEvent) { Editor.app.setDragMode(EditorApplication.DragMode.X);
+            public void actionPerformed(ActionEvent actionEvent) {
+                Editor.app.setDragMode(EditorApplication.DragMode.X);
             }
         };
         yDragMode = new ActionListener() {
             @Override
-            public void actionPerformed(ActionEvent actionEvent) { Editor.app.setDragMode(EditorApplication.DragMode.Y);
+            public void actionPerformed(ActionEvent actionEvent) {
+                Editor.app.setDragMode(EditorApplication.DragMode.Y);
             }
         };
         zDragMode = new ActionListener() {
             @Override
-            public void actionPerformed(ActionEvent actionEvent) { Editor.app.setDragMode(EditorApplication.DragMode.Z);
+            public void actionPerformed(ActionEvent actionEvent) {
+                Editor.app.setDragMode(EditorApplication.DragMode.Z);
             }
         };
+
         rotateMode = new ActionListener() {
             @Override
-            public void actionPerformed(ActionEvent actionEvent) { Editor.app.setMoveMode(EditorApplication.MoveMode.ROTATE);
+            public void actionPerformed(ActionEvent actionEvent) {
+                Editor.app.setMoveMode(EditorApplication.MoveMode.ROTATE);
+            }
+        };
+
+        turnLeftAction = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                Editor.app.turnPickedEntityLeft();
+                Editor.app.refresh();
+            }
+        };
+
+        turnRightAction = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                Editor.app.turnPickedEntityRight();
+                Editor.app.refresh();
             }
         };
 

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -230,8 +230,6 @@ public class EditorApplication implements ApplicationListener {
 
     protected EntityManager entityManager;
 
-	boolean readRotate;
-
 	Mesh cubeMesh;
     Mesh gridMesh;
 
@@ -1611,6 +1609,26 @@ public class EditorApplication implements ApplicationListener {
 		}
 	}
 
+	public void turnPickedEntityLeft() {
+		if(Editor.selection.picked != null) {
+			Editor.selection.picked.rotate90();
+			for(Entity e : Editor.selection.selected) {
+				e.rotate90();
+			}
+			refreshEntity(Editor.selection.picked);
+		}
+	}
+
+	public void turnPickedEntityRight() {
+		if(Editor.selection.picked != null) {
+			Editor.selection.picked.rotate90Reversed();
+			for(Entity e : Editor.selection.selected) {
+				e.rotate90Reversed();
+			}
+			refreshEntity(Editor.selection.picked);
+		}
+	}
+
 	public void setPickedWallTexture(int tex, String wallTexAtlas) {
 		pickedWallTexture = tex;
         pickedWallTextureAtlas = wallTexAtlas != null ? wallTexAtlas : TextureAtlas.cachedRepeatingAtlases.firstKey();
@@ -1990,20 +2008,6 @@ public class EditorApplication implements ApplicationListener {
 			else if(Gdx.input.isKeyPressed(Keys.NUM_2)) {
 				pickTextureAtSurface();
 			}
-		}
-		else {
-			// rotate entity by 90 degrees
-			if(Gdx.input.isKeyPressed(Keys.T)) {
-				if(!readRotate) {
-					readRotate = true;
-					Editor.selection.picked.rotate90();
-					for(Entity e : Editor.selection.selected) {
-						e.rotate90();
-					}
-					refreshEntity(Editor.selection.picked);
-				}
-			}
-			else readRotate = false;
 		}
 
 		if(player != null) {

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorCameraController.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorCameraController.java
@@ -66,7 +66,7 @@ public class EditorCameraController extends InputAdapter implements EditorSubsys
     }
 
     private boolean canRotateWithArrowKeys() {
-        return !Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT);
+        return !Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT) && !Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT);
     }
 
     private boolean inFastMode() {

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
@@ -330,6 +330,9 @@ public class EditorUi {
                     .addItem(new MenuItem("Constrain to Z-axis", smallSkin, actions.zDragMode).setAccelerator(new MenuAccelerator(Keys.Z, false, false)))
                 )
                 .addItem(new MenuItem("Rotate", smallSkin, actions.rotateMode).setAccelerator(new MenuAccelerator(Keys.R, false, false)))
+                .addItem(new MenuItem("Turn", smallSkin)
+                        .addItem(new MenuItem("Clockwise", smallSkin, actions.turnLeftAction).setAccelerator(new MenuAccelerator(Keys.LEFT, true, false)))
+                        .addItem(new MenuItem("Counter-clockwise", smallSkin, actions.turnRightAction).setAccelerator(new MenuAccelerator(Keys.RIGHT, true, false))))
         );
 
         menuBar.addItem(
@@ -347,7 +350,7 @@ public class EditorUi {
                 .addSeparator()
                 .addItem(new MenuItem("Rotate Level", smallSkin)
                     .addItem(new MenuItem("Clockwise", smallSkin, actions.rotateLeftAction))
-                    .addItem(new MenuItem("Counter-Clockwise", smallSkin, actions.rotateRightAction)))
+                    .addItem(new MenuItem("Counter-clockwise", smallSkin, actions.rotateRightAction)))
                 .addItem(new MenuItem("Resize Level", smallSkin, resizeWindowAction))
                 .addSeparator()
                 .addItem(new MenuItem("Set Theme", smallSkin, setThemeAction))


### PR DESCRIPTION
With regards to #96, the current behaviour was defined in the `tick()` function of the `EditorApplication` which made it ignore the input and focus checks.

This PR moves the behaviour to `MenuItem`s and assigns new commands, `Ctrl + Left` and `Ctrl + Right` for rotation, CW and CCW respectively (as the original `T` key binding is reserved for texture rotation actions).