### PR TITLE
Add Action To Test Level At Player Start Marker

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorActions.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorActions.java
@@ -14,7 +14,8 @@ public class EditorActions {
     public ActionListener exitAction;
     public ActionListener rotateLeftAction;
     public ActionListener rotateRightAction;
-    public ActionListener playAction;
+    public ActionListener playFromCameraAction;
+    public ActionListener playFromStartAction;
     public ActionListener carveAction;
     public ActionListener paintAction;
     public ActionListener deleteAction;
@@ -108,9 +109,15 @@ public class EditorActions {
             }
         };
 
-        playAction = new ActionListener() {
+        playFromCameraAction = new ActionListener() {
             public void actionPerformed(ActionEvent event) {
-                Editor.app.testLevel();
+                Editor.app.testLevel(true);
+            }
+        };
+
+        playFromStartAction = new ActionListener() {
+            public void actionPerformed(ActionEvent event) {
+                Editor.app.testLevel(false);
             }
         };
 

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -2117,6 +2117,8 @@ public class EditorApplication implements ApplicationListener {
     }
 
 	public void testLevel(boolean useCameraPosition) {
+		editorInput.resetKeys();
+
 		gameApp = new GameApplication();
 		GameApplication.editorRunning = true;
 

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -2116,7 +2116,7 @@ public class EditorApplication implements ApplicationListener {
         controlPoints.clear();
     }
 
-	public void testLevel() {
+	public void testLevel(boolean useCameraPosition) {
 		gameApp = new GameApplication();
 		GameApplication.editorRunning = true;
 
@@ -2127,16 +2127,35 @@ public class EditorApplication implements ApplicationListener {
 		previewLevel.genTheme = DungeonGenerator.GetGenData(previewLevel.theme);
 
 		gameApp.createFromEditor(previewLevel);
-
-		Vector3 cameraPosition = cameraController.getPosition();
-		Vector2 cameraRotation = cameraController.getRotation();
-
-		Game.instance.player.x = cameraPosition.x;
-		Game.instance.player.y = cameraPosition.y - Game.instance.player.eyeHeight;
-		Game.instance.player.z = cameraPosition.z;
-		Game.instance.player.rot = cameraRotation.x;
-		Game.instance.player.yrot = -cameraRotation.y;
 		Game.isDebugMode = true;
+
+		EditorMarker startMarker = null;
+		if (!useCameraPosition) {
+			for (EditorMarker marker : level.editorMarkers) {
+				if (marker.type == Markers.playerStart || marker.type == Markers.stairUp) {
+					startMarker = marker;
+					break;
+				}
+			}
+		}
+
+		if (!useCameraPosition && startMarker != null) {
+			Game.instance.player.x = startMarker.x + 0.5f;
+			Game.instance.player.y = startMarker.y + 0.5f;
+			Game.instance.player.z = previewLevel.getTile((int) Game.instance.player.x, (int) Game.instance.player.y)
+					.getFloorHeight() + 0.5f;
+
+			Game.instance.player.rot = (float) Math.toRadians(-(startMarker.rot + 180f));
+		} else {
+			Vector3 cameraPosition = cameraController.getPosition();
+			Vector2 cameraRotation = cameraController.getRotation();
+	
+			Game.instance.player.x = cameraPosition.x;
+			Game.instance.player.y = cameraPosition.y - Game.instance.player.eyeHeight;
+			Game.instance.player.z = cameraPosition.z;
+			Game.instance.player.rot = cameraRotation.x;
+			Game.instance.player.yrot = -cameraRotation.y;
+		}
 	}
 
 	public void initTextures() {

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
@@ -346,7 +346,10 @@ public class EditorUi {
 
         menuBar.addItem(
             new MenuItem("Level", smallSkin)
-                .addItem(new MenuItem("Test Level", smallSkin, actions.playAction).setAccelerator(new MenuAccelerator(Keys.P, false, false)))
+                        .addItem(new MenuItem("Test Level From Camera", smallSkin, actions.playFromCameraAction)
+                                .setAccelerator(new MenuAccelerator(Keys.P, false, false)))
+                        .addItem(new MenuItem("Test Level From Start", smallSkin, actions.playFromStartAction)
+                                .setAccelerator(new MenuAccelerator(Keys.P, false, true)))
                 .addSeparator()
                 .addItem(new MenuItem("Rotate Level", smallSkin)
                     .addItem(new MenuItem("Clockwise", smallSkin, actions.rotateLeftAction))
@@ -383,7 +386,7 @@ public class EditorUi {
             @Override
             public void clicked(InputEvent event, float x, float y) {
                 if (event.getType().name().equals("touchUp")) {
-                    Editor.app.testLevel();
+                    Editor.app.testLevel(false);
                 }
             }
         });

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
@@ -346,9 +346,9 @@ public class EditorUi {
 
         menuBar.addItem(
             new MenuItem("Level", smallSkin)
-                        .addItem(new MenuItem("Test Level From Camera", smallSkin, actions.playFromCameraAction)
+                        .addItem(new MenuItem("Play From Camera", smallSkin, actions.playFromCameraAction)
                                 .setAccelerator(new MenuAccelerator(Keys.P, false, false)))
-                        .addItem(new MenuItem("Test Level From Start", smallSkin, actions.playFromStartAction)
+                        .addItem(new MenuItem("Play From Start", smallSkin, actions.playFromStartAction)
                                 .setAccelerator(new MenuAccelerator(Keys.P, false, true)))
                 .addSeparator()
                 .addItem(new MenuItem("Rotate Level", smallSkin)


### PR DESCRIPTION
Closes #121. Let's the user press `Shift+P` in order to start level at defined player start or stairs up marker.

**Known Issues:**
- Player rotation uses marker rotation which sometimes is not properly aligned with level geometry