### PR TITLE
Projected decals copy constructor should honor spriteAtlas field

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/ProjectedDecal.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/ProjectedDecal.java
@@ -67,6 +67,7 @@ public class ProjectedDecal extends DirectionalEntity {
 	public ProjectedDecal(ProjectedDecal decal) {
 		artType = decal.artType;
 		tex = decal.tex;
+		spriteAtlas = decal.spriteAtlas;
 		decalWidth = decal.decalWidth;
 		decalHeight = decal.decalHeight;
 		isDynamic = false;


### PR DESCRIPTION
# Summary
The ProjectedDecal copy constructor does not preserve the `spriteAtlas` field. The specific use case here is to enable monster blood splat textures to come from a different sprite atlas other than the default.