### PR TITLE
Adding missed schema file to Interfaces.schema.json

### DIFF
--- a/jsonschema/current/Interfaces.schema.json
+++ b/jsonschema/current/Interfaces.schema.json
@@ -56,6 +56,7 @@
                 {"$ref": "dungeoneer/entities/items/Decoration.schema.json"},
                 {"$ref": "dungeoneer/entities/items/Gun.schema.json"},
                 {"$ref": "dungeoneer/entities/items/ItemStack.schema.json"},
+                {"$ref": "dungeoneer/entities/items/Scroll.schema.json"},
                 {"$ref": "dungeoneer/entities/items/Sword.schema.json"},
                 {"$ref": "dungeoneer/entities/items/Weapon.schema.json"},
                 {"$ref": "dungeoneer/entities/projectiles/Missile.schema.json"},


### PR DESCRIPTION
# Summary
The scrolls item schema was missed and not included in the `Interfaces.schema.json` file.