### PR TITLE
Stop mesh item from newing up drawable every frame

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Item.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Item.java
@@ -505,20 +505,25 @@ public class Item extends Entity {
 
 	protected void updateDrawableInternal(boolean held) {
 		String meshToUse = getMeshToUse(held);
-		if(meshToUse != null && (((lastMeshFile != meshToUse)) || (textureFile == null || (lastTextureFile != textureFile)))) {
-			String pickedMeshFile = meshToUse;
-			if(meshToUse.contains(",")) {
-				String[] files = meshToUse.split(",");
-				pickedMeshFile = files[Game.rand.nextInt(files.length)];
-			}
+		if(meshToUse != null) {
+			// Check if we need to create/update our mesh drawable
+			if (!meshToUse.equals(lastMeshFile) || (textureFile != null && !textureFile.equals(lastTextureFile))) {
+				String pickedMeshFile = meshToUse;
+				if (meshToUse.contains(",")) {
+					String[] files = meshToUse.split(",");
+					pickedMeshFile = files[Game.rand.nextInt(files.length)];
+				}
 
-			String pickedTextureFile = textureFile;
-			if(textureFile.contains(",")) {
-				String[] files = textureFile.split(",");
-				pickedTextureFile = files[Game.rand.nextInt(files.length)];
-			}
+				String pickedTextureFile = textureFile;
+				if (textureFile.contains(",")) {
+					String[] files = textureFile.split(",");
+					pickedTextureFile = files[Game.rand.nextInt(files.length)];
+				}
 
-			drawable = new DrawableMesh(pickedMeshFile, pickedTextureFile);
+				drawable = new DrawableMesh(pickedMeshFile, pickedTextureFile);
+				lastMeshFile = meshToUse;
+				lastTextureFile = textureFile;
+			}
 		} else {
 			// Make sure we stop using the mesh version when done
 			if(drawable instanceof DrawableMesh)


### PR DESCRIPTION
# Summary
Due to a small logic error, we were newing up a mesh drawable every frame for mesh items. The fix was:
1. Split out the case for if `meshToUse` was null or not.
2. Put the check to see if our mesh needs updating inside the previous check.
3. Actually record the `lastMeshFile` and `lastTextureFile` values.
4. Use `String.equals()` for sting equality checks.