### PR TITLE
Fix for not being able to select water tiles in the editor

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -3102,7 +3102,11 @@ public class EditorApplication implements ApplicationListener {
 
 			// Which surface should we paint?
 			if(pickedSurface.tileSurface == TileSurface.Floor) {
-				d.setPosition((int)pickedSurface.position.x + 0.5f, t.floorHeight, (int)pickedSurface.position.z + 0.5f);
+				float floorHeightOffset = 0f;
+				if(t.data.isWater)
+					floorHeightOffset = 0.08f;
+
+				d.setPosition((int)pickedSurface.position.x + 0.5f, t.floorHeight + floorHeightOffset, (int)pickedSurface.position.z + 0.5f);
 				d.setRotation(Vector3.Y, Vector3.Y);
 
 				d.setTopLeftOffset(0, 0, t.slopeNE);

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -29,6 +29,7 @@ import com.badlogic.gdx.utils.*;
 import com.interrupt.dungeoneer.Audio;
 import com.interrupt.dungeoneer.*;
 import com.interrupt.dungeoneer.collision.Collidor;
+import com.interrupt.dungeoneer.collision.CollisionTriangle;
 import com.interrupt.dungeoneer.editor.file.EditorFile;
 import com.interrupt.dungeoneer.editor.gfx.SurfacePickerDecal;
 import com.interrupt.dungeoneer.editor.gizmos.Gizmo;
@@ -3745,7 +3746,7 @@ public class EditorApplication implements ApplicationListener {
         return moveMode;
     }
 
-    public Array<Triangle> GetCollisionTriangles() {
+    public Array<CollisionTriangle> GetCollisionTriangles() {
         return GlRenderer.triangleSpatialHash.getAllTriangles();
     }
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/collision/Collidor.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/collision/Collidor.java
@@ -86,7 +86,7 @@ public class Collidor {
 	 * @param triangles The triangles
 	 * @param intersection The nearest intersection point (optional)
 	 * @return Whether the ray and the triangles intersect. */
-	public static boolean intersectRayTriangles(Ray ray, Array<Triangle> triangles, Vector3 intersection, Vector3 normal) {
+	public static boolean intersectRayTriangles(Ray ray, Array<CollisionTriangle> triangles, Vector3 intersection, Vector3 normal) {
 		float min_dist = Float.MAX_VALUE;
 		boolean hit = false;
 
@@ -134,7 +134,7 @@ public class Collidor {
 		}
 	}
 
-	public static boolean intersectRayForwardFacingTriangles(Ray ray, Camera camera, Array<Triangle> triangles, Vector3 intersection, Vector3 normal) {
+	public static boolean intersectRayForwardFacingTriangles(Ray ray, Camera camera, Array<CollisionTriangle> triangles, Vector3 intersection, Vector3 normal) {
 		float min_dist = Float.MAX_VALUE;
 		boolean hit = false;
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/collision/CollisionTriangle.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/collision/CollisionTriangle.java
@@ -1,0 +1,20 @@
+package com.interrupt.dungeoneer.collision;
+
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.utils.Triangle;
+
+public class CollisionTriangle extends Triangle {
+
+    public enum TriangleCollisionType { WORLD, WATER };
+
+    public TriangleCollisionType collisionType = TriangleCollisionType.WORLD;
+
+    public CollisionTriangle(Vector3 v1, Vector3 v2, Vector3 v3 ) {
+        super(v1, v2, v3);
+    }
+
+    public CollisionTriangle(Vector3 v1, Vector3 v2, Vector3 v3, TriangleCollisionType colType) {
+        super(v1, v2, v3);
+        collisionType = colType;
+    }
+}

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2746,6 +2746,8 @@ public class GlRenderer {
 						if(!c.Empty()) {
 							chunks.add(c);
 							c.tesselators.world.addCollisionTriangles(triangleSpatialHash);
+							c.tesselators.water.addCollisionTriangles(triangleSpatialHash);
+							c.tesselators.waterfall.addCollisionTriangles(triangleSpatialHash);
 						}
 					}
 				}
@@ -2761,6 +2763,8 @@ public class GlRenderer {
 					triangleSpatialHash.dropWorldChunk(c);
 					c.Tesselate(loadedLevel, this);
 					c.tesselators.world.addCollisionTriangles(triangleSpatialHash);
+					c.tesselators.water.addCollisionTriangles(triangleSpatialHash);
+					c.tesselators.waterfall.addCollisionTriangles(triangleSpatialHash);
 				}
 			}
 		}

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/TesselatorGroup.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/TesselatorGroup.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ArrayMap;
 import com.badlogic.gdx.utils.Triangle;
+import com.interrupt.dungeoneer.collision.CollisionTriangle;
 import com.interrupt.dungeoneer.gfx.decals.DDecal;
 import com.interrupt.dungeoneer.gfx.shaders.ShaderInfo;
 import com.interrupt.dungeoneer.partitioning.TriangleSpatialHash;
@@ -137,13 +138,18 @@ public class TesselatorGroup {
     }
 
     public void addCollisionTriangles(TriangleSpatialHash triangleSpatialHash) {
+        addCollisionTriangles(triangleSpatialHash, CollisionTriangle.TriangleCollisionType.WORLD);
+    }
+
+    public void addCollisionTriangles(TriangleSpatialHash triangleSpatialHash, CollisionTriangle.TriangleCollisionType collisionType) {
         for(int ti = 0; ti < tesselators.size; ti++) {
             Tesselator tesselator = tesselators.getValueAt(ti);
             for (int i = 0; i < tesselator.collisionTriangles.size - 2; i += 3) {
                 triangleSpatialHash.AddTriangle(
-                        new Triangle(tesselator.collisionTriangles.get(i),
+                        new CollisionTriangle(tesselator.collisionTriangles.get(i),
                                 tesselator.collisionTriangles.get(i + 1),
-                                tesselator.collisionTriangles.get(i + 2)));
+                                tesselator.collisionTriangles.get(i + 2),
+                                collisionType));
             }
         }
     }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/partitioning/TriangleSpatialHash.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/partitioning/TriangleSpatialHash.java
@@ -3,18 +3,18 @@ package com.interrupt.dungeoneer.partitioning;
 import com.badlogic.gdx.math.Frustum;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.Ray;
-import com.badlogic.gdx.utils.*;
-import com.interrupt.dungeoneer.GameManager;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.IntArray;
+import com.badlogic.gdx.utils.IntMap;
+import com.interrupt.dungeoneer.collision.CollisionTriangle;
 import com.interrupt.dungeoneer.game.CachePools;
 import com.interrupt.dungeoneer.gfx.WorldChunk;
-import com.interrupt.dungeoneer.tiles.Tile;
-import com.interrupt.dungeoneer.tiles.Tile.TileSpaceType;
 
 public class TriangleSpatialHash {
 	private final int cellSize;
-	private IntMap<Array<Triangle>> hash = new IntMap<Array<Triangle>>();
+	private IntMap<Array<CollisionTriangle>> hash = new IntMap<>();
 	
-	private Array<Triangle> temp = new Array<Triangle>();
+	private Array<CollisionTriangle> temp = new Array<>();
 	private IntArray cellKeys = new IntArray();
 	
 	public TriangleSpatialHash(int cellSize)  {
@@ -107,10 +107,10 @@ public class TriangleSpatialHash {
 		return cellKeys;
 	}
 	
-	private void PutTriangle(int key, Triangle e) {
-		Array<Triangle> eList = hash.get(key);
+	private void PutTriangle(int key, CollisionTriangle e) {
+		Array<CollisionTriangle> eList = hash.get(key);
 		if(eList == null) {
-			eList = new Array<Triangle>();
+			eList = new Array<CollisionTriangle>();
 			eList.add(e);
 			
 			hash.put(key, eList);
@@ -121,7 +121,7 @@ public class TriangleSpatialHash {
 		}
 	}
 	
-	public void AddTriangle(Triangle e) {
+	public void AddTriangle(CollisionTriangle e) {
 		int key = getKey(e.v1.x, e.v1.z);
 		PutTriangle(key, e);
 		
@@ -139,7 +139,7 @@ public class TriangleSpatialHash {
 		// drop triangles in these cells
 		for(int i = 0; i < cells.size; i++) {
 			int cell = cells.get(i);
-			Array<Triangle> inCell = hash.get(cell);
+			Array<CollisionTriangle> inCell = hash.get(cell);
 			if(inCell != null) {
 				inCell.clear();
 			}
@@ -147,16 +147,16 @@ public class TriangleSpatialHash {
 	}
 	
 	// Returns triangles found near an entity
-	public Array<Triangle> getTrianglesAt(float x, float y, float colSize) {
+	public Array<CollisionTriangle> getTrianglesAt(float x, float y, float colSize) {
 		temp.clear();
 		IntArray cells = getCellsNear(x, y, colSize);
 		
 		// look in all the nearby cells for triangles
 		for(int i = 0; i < cells.size; i++) {
 			int cell = cells.get(i);
-			Array<Triangle> inCell = hash.get(cell);
+			Array<CollisionTriangle> inCell = hash.get(cell);
 			if(inCell != null) {
-				for(Triangle triangle : inCell) {
+				for(CollisionTriangle triangle : inCell) {
 					if(!temp.contains(triangle, true)) temp.add(triangle);
 				}
 			}
@@ -166,16 +166,16 @@ public class TriangleSpatialHash {
 	}
 	
 	// Returns all the triangles found along a ray
-	public Array<Triangle> getTrianglesAlong(Ray ray, float length) {
+	public Array<CollisionTriangle> getTrianglesAlong(Ray ray, float length) {
 		temp.clear();
 		IntArray cells = getCellsAlong(ray, length);
 		
 		// look in all the nearby cells for triangles
 		for(int i = 0; i < cells.size; i++) {
 			int cell = cells.get(i);
-			Array<Triangle> inCell = hash.get(cell);
+			Array<CollisionTriangle> inCell = hash.get(cell);
 			if(inCell != null) {
-				for(Triangle triangle : inCell) {
+				for(CollisionTriangle triangle : inCell) {
 					if(!temp.contains(triangle, true)) temp.add(triangle);
 				}
 			}
@@ -185,16 +185,16 @@ public class TriangleSpatialHash {
 	}
 	
 	// Returns all the triangles in a frustum
-	public Array<Triangle> getTrianglesIn(Frustum frustum) {
+	public Array<CollisionTriangle> getTrianglesIn(Frustum frustum) {
 		temp.clear();
 		IntArray cells = getCellsIn(frustum);
 		
 		// look in all the nearby cells for triangles
 		for(int i = 0; i < cells.size; i++) {
 			int cell = cells.get(i);
-			Array<Triangle> inCell = hash.get(cell);
+			Array<CollisionTriangle> inCell = hash.get(cell);
 			if(inCell != null) {
-				for(Triangle triangle : inCell) {
+				for(CollisionTriangle triangle : inCell) {
 					if(!temp.contains(triangle, true)) temp.add(triangle);
 				}
 			}
@@ -208,15 +208,15 @@ public class TriangleSpatialHash {
 	}
 	
 	public void Flush() {
-		for(Array<Triangle> val : hash.values()) {
+		for(Array<CollisionTriangle> val : hash.values()) {
 			val.clear();
 		}
 	}
 
-    public Array<Triangle> getAllTriangles() {
+    public Array<CollisionTriangle> getAllTriangles() {
         temp.clear();
 
-        for(Array<Triangle> val : hash.values()) {
+        for(Array<CollisionTriangle> val : hash.values()) {
             temp.addAll(val);
         }
 


### PR DESCRIPTION
- Main issue here was that collision triangles for the water and waterfall tesselated meshes were not being added to the triangle spatial hash
- This was because when triangles are in the spatial hash, they can get decals projected on them
- Switched our triangle collision system to use a new type called CollisionTriangle that can have set collision types
- Projected decals will filter out CollisionTriangles that have the collisionType of Water