### PR TITLE
Alternative level templates not recognized

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/generator/SectionDefinition.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/generator/SectionDefinition.java
@@ -1,7 +1,5 @@
 package com.interrupt.dungeoneer.generator;
 
-import java.util.Random;
-
 import com.badlogic.gdx.utils.Array;
 import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.serializers.KryoSerializer;
@@ -27,8 +25,6 @@ public class SectionDefinition {
 
     /** Array of level template tiers spawn probabilities. Use indices of the `levelTemplates` array. */
     public Array<Integer> levelTemplateTiers = null;
-
-    private Random randomGenerator = new Random();
 
     /** Returns an array of level templates, ordered by floors, transition level last. */
     public Array<Level> buildLevels() {
@@ -57,15 +53,10 @@ public class SectionDefinition {
 
         if (levelTemplateTiers != null && levelTemplateTiers.size > 0) {
             try {
-                tier = levelTemplateTiers.get(randomGenerator.nextInt(levelTemplateTiers.size));
+                tier = levelTemplateTiers.random();
             } catch (IndexOutOfBoundsException exception) {
                 tier = -1;
             }
-        }
-
-        // When no tiers given fallback to an even distribution.
-        if (tier == -1) {
-            tier = randomGenerator.nextInt(levelTemplates.size);
         }
 
         return tier;
@@ -77,7 +68,7 @@ public class SectionDefinition {
         Level levelTemplate;
 
         try {
-            levelTemplate = levelTemplates.get(tier);
+            levelTemplate = (tier == -1) ? levelTemplates.random() : levelTemplates.get(tier);
         } catch (IndexOutOfBoundsException exception) {
             return null;
         }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/generator/SectionDefinition.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/generator/SectionDefinition.java
@@ -23,8 +23,8 @@ public class SectionDefinition {
     /** Array of possible level templates to use when making floors. */
     public Array<Level> levelTemplates = null;
 
-    /** Array of level template tiers spawn probabilities. Use indices of the `levelTemplates` array. */
-    public Array<Integer> levelTemplateTiers = null;
+    /** Array of level template indices corresponding to spawn probabilities. Use indices of the `levelTemplates` array. */
+    public Array<Integer> levelTemplateDistribution = null;
 
     /** Returns an array of level templates, ordered by floors, transition level last. */
     public Array<Level> buildLevels() {
@@ -47,28 +47,28 @@ public class SectionDefinition {
         return levels;
     }
 
-    /** Picks a level template tier. */
-    private int pickLevelTemplateTier() {
-        int tier = -1;
+    /** Picks a level template index. */
+    private int pickLevelTemplateIndex() {
+        int index = -1;
 
-        if (levelTemplateTiers != null && levelTemplateTiers.size > 0) {
+        if (hasLevelTemplateDistribution()) {
             try {
-                tier = levelTemplateTiers.random();
+                index = levelTemplateDistribution.random();
             } catch (IndexOutOfBoundsException exception) {
-                tier = -1;
+                index = -1;
             }
         }
 
-        return tier;
+        return index;
     }
 
     /** Picks a level template. */
     private Level pickLevelTemplate(int floor) {
-        int tier = pickLevelTemplateTier();
+        int index = pickLevelTemplateIndex();
         Level levelTemplate;
 
         try {
-            levelTemplate = (tier == -1) ? levelTemplates.random() : levelTemplates.get(tier);
+            levelTemplate = (index == -1) ? levelTemplates.random() : levelTemplates.get(index);
         } catch (IndexOutOfBoundsException exception) {
             return null;
         }
@@ -109,6 +109,11 @@ public class SectionDefinition {
     /** Does the `SectionDefinition` have at least one level template? */
     private boolean hasLevelTemplates() {
         return levelTemplates != null && levelTemplates.size > 0;
+    }
+
+    /** Does the `SectionDefinition` have at least one index set? */
+    private boolean hasLevelTemplateDistribution() {
+        return levelTemplateDistribution != null && levelTemplateDistribution.size > 0;
     }
 
     /** Does the `SectionDefinition` have at least one floor? */

--- a/Dungeoneer/src/com/interrupt/dungeoneer/generator/SectionDefinition.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/generator/SectionDefinition.java
@@ -53,16 +53,19 @@ public class SectionDefinition {
 
     /** Picks a level template tier. */
     private int pickLevelTemplateTier() {
-        if (levelTemplateTiers == null || levelTemplateTiers.size <= 0) {
-            return 0;
+        int tier = -1;
+
+        if (levelTemplateTiers != null && levelTemplateTiers.size > 0) {
+            try {
+                tier = levelTemplateTiers.get(randomGenerator.nextInt(levelTemplateTiers.size));
+            } catch (IndexOutOfBoundsException exception) {
+                tier = -1;
+            }
         }
 
-        int tier = 0;
-
-        try {
-            tier = levelTemplateTiers.get(randomGenerator.nextInt(levelTemplateTiers.size));
-        } catch (IndexOutOfBoundsException exception) {
-            tier = 0;
+        // When no tiers given fallback to an even distribution.
+        if (tier == -1) {
+            tier = randomGenerator.nextInt(levelTemplates.size);
         }
 
         return tier;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/generator/SectionDefinition.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/generator/SectionDefinition.java
@@ -5,8 +5,6 @@ import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.serializers.KryoSerializer;
 
 public class SectionDefinition {
-    public SectionDefinition() { }
-
     /** What kind of loot should we drop here? */
     public int difficultyLevel = 1;
 
@@ -19,36 +17,78 @@ public class SectionDefinition {
     /** Number of levels in this section. */
     public int floors = 2;
 
-    /** Transition level to use after all floors in this section. If numFloors is 0, just use this level. */
+    /** Transition level to use after all floors in this section. If `floors` is 0, just use this level. */
     public Level transitionLevel = null;
 
     /** Array of possible level templates to use when making floors. */
     public Array<Level> levelTemplates = null;
 
+    /** Returns an array of level templates, ordered by floors, transition level last. */
     public Array<Level> buildLevels() {
-        Array<Level> l = new Array<Level>();
+        Array<Level> levels = new Array<>();
 
-        // make the levels for this dungeon section
-        for(int i = 0; i < floors; i++) {
-            if(levelTemplates != null && levelTemplates.size > 0) {
-                Level picked = levelTemplates.first();
-                Level copy = (Level)KryoSerializer.copyObject(picked);
-
-                if(copy.levelName == null || copy.levelName.equals(""))
-                    copy.levelName = name + " " + (i + 1);
-
-                copy.dungeonLevel = difficultyLevel + i;
-                l.add(copy);
+        if(hasFloors() && hasLevelTemplates()) {
+            for(int floor = 0; floor < floors; floor++) {
+                levels.add(pickLevelTemplate(floor));
             }
         }
 
-        // add a transition level if one was set
-        if(transitionLevel != null) {
-            Level copy = (Level)KryoSerializer.copyObject(transitionLevel);
-            copy.dungeonLevel = difficultyLevel + floors;
-            l.add(copy);
+        if (hasTransitionLevel()) {
+            levels.add(pickTransitionLevel());
         }
 
-        return l;
+        return levels;
+    }
+
+    /** Picks a level template. */
+    private Level pickLevelTemplate(int floor) {
+        Level levelTemplate = levelTemplates.first();
+        Level level = copyLevelDefinition(levelTemplate);
+
+        level.levelName = getLevelName(level, floor);
+        level.dungeonLevel = getDungeonLevel(floor);
+
+        return level;
+    }
+
+    /** Picks a transition level. */
+    private Level pickTransitionLevel() {
+        Level level = copyLevelDefinition(transitionLevel);
+        level.dungeonLevel = getDungeonLevel(floors);
+        return level;
+    }
+
+    /** Returns the level name. */
+    private String getLevelName(Level level, int floor) {
+        if(level.levelName == null || level.levelName.equals("")) {
+            return name + " " + (floor + 1);
+        }
+
+        return level.levelName;
+    }
+
+    /** Returns the dungeon level. */
+    private int getDungeonLevel(int floor) {
+        return difficultyLevel + floor;
+    }
+
+    /** Returns a copy of a level definition. */
+    private Level copyLevelDefinition(Level level) {
+        return (Level)KryoSerializer.copyObject(level);
+    }
+
+    /** Does the `SectionDefinition` have at least one level template? */
+    private boolean hasLevelTemplates() {
+        return levelTemplates != null && levelTemplates.size > 0;
+    }
+
+    /** Does the `SectionDefinition` have at least one floor? */
+    private boolean hasFloors() {
+        return floors > 0;
+    }
+
+    /** Does the `SectionDefinition` have a transition level? */
+    private boolean hasTransitionLevel() {
+        return transitionLevel != null;
     }
 }

--- a/jsonschema/current/dungeoneer/generator/SectionDefinition.schema.json
+++ b/jsonschema/current/dungeoneer/generator/SectionDefinition.schema.json
@@ -30,13 +30,20 @@
         },
         "transitionLevel": {
             "$ref": "../game/Level.schema.json",
-            "description": "Transition level to use after all floors in this section. If numFloors is 0, just use this level."
+            "description": "Transition level to use after all floors in this section. If `floors` is 0, just use this level."
         },
         "levelTemplates": {
             "type": "array",
             "items": {
                 "$ref": "../game/Level.schema.json",
                 "description": "Array of possible level templates to use when making floors."
+            }
+        },
+        "levelTemplateTiers": {
+            "type": "array",
+            "items": {
+                "type": "integer",
+                "description": "Array of level template tiers spawn probabilities. Use indices of the `levelTemplates` array."
             }
         }
     }

--- a/jsonschema/current/dungeoneer/generator/SectionDefinition.schema.json
+++ b/jsonschema/current/dungeoneer/generator/SectionDefinition.schema.json
@@ -39,11 +39,11 @@
                 "description": "Array of possible level templates to use when making floors."
             }
         },
-        "levelTemplateTiers": {
+        "levelTemplateDistribution": {
             "type": "array",
             "items": {
                 "type": "integer",
-                "description": "Array of level template tiers spawn probabilities. Use indices of the `levelTemplates` array."
+                "description": "Array of level template indices corresponding to spawn probabilities. Use indices of the `levelTemplates` array."
             }
         }
     }


### PR DESCRIPTION
## Summary

Refactors the class `SectionDefinition`. Now picks a level template at random which fixes #114. A new property `levelTemplateDistribution` can be used in `section.dat` to alter the spawn probabilities. It refers to the index of a level template of the `levelTemplates` property. If `levelTemplateDistribution` is not given, the probabilities are equal.

The following example simulates a possible scenario of common, uncommon and rare level templates.

```json
// section.dat
{
  ...,
  "levelTemplateDistribution": [0, 0, 0, 0, 1, 1, 2]
}
```

Could be useful to define an example section with this new feature in #118.