### PR TITLE
Loading Levels Not Validated

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorOptions.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorOptions.java
@@ -40,8 +40,12 @@ public class EditorOptions {
         Editor.options.save();
     }
 
-    public void addRecentlyOpenedFile(String path) {
+    public void removeRecentlyOpenedFile(String path) {
         recentlyOpenedFiles.removeValue(path, false);
+    }
+
+    public void addRecentlyOpenedFile(String path) {
+        removeRecentlyOpenedFile(path);
         recentlyOpenedFiles.insert(0, path);
     }
 }

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorOptions.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorOptions.java
@@ -39,4 +39,9 @@ public class EditorOptions {
     public void dispose() {
         Editor.options.save();
     }
+
+    public void addRecentlyOpenedFile(String path) {
+        recentlyOpenedFiles.removeValue(path, false);
+        recentlyOpenedFiles.insert(0, path);
+    }
 }

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
@@ -286,7 +286,7 @@ public class EditorFile {
                 } else if (name.endsWith(".dat")) {
                     level = loadDatFile(file);
                 } else {
-                    showWarningDialog("Unkown extension. Cannot load '" + name + "'.");
+                    showWarningDialog("Unknown extension. Cannot load '" + name + "'.");
                     return;
                 }
             } catch (SerializationException exception) {

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
@@ -293,6 +293,11 @@ public class EditorFile {
                 return;
             }
 
+            if (!validateLevel(level)) {
+                showWarningDialog("Invalid level data. Cannot load '" + file.name() + "'.");
+                return;
+            }
+
             Editor.app.file = new EditorFile(file);
 
             Editor.app.level = level;
@@ -305,6 +310,7 @@ public class EditorFile {
 
             Editor.options.addRecentlyOpenedFile(file.path());
 
+            Editor.app.clearEntitySelection();
             Editor.app.viewSelected();
         } else {
             showWarningDialog("File does not exist. Cannot load '" + name + "'.");
@@ -345,6 +351,11 @@ public class EditorFile {
         level.init(Level.Source.EDITOR);
 
         return level;
+    }
+
+    /** Validates that a given level is loaded correctly from storage. */
+    private boolean validateLevel(Level level) {
+        return level.entities != null;
     }
 
     /** Prompt user and create a new level. */

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
@@ -317,6 +317,7 @@ public class EditorFile {
             Editor.app.clearEntitySelection();
             Editor.app.viewSelected();
         } else {
+            Editor.options.removeRecentlyOpenedFile(file.path());
             showWarningDialog("File does not exist. Cannot load '" + name + "'.");
             return;
         }

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
+import com.badlogic.gdx.utils.SerializationException;
 import com.badlogic.gdx.utils.TimeUtils;
 import com.interrupt.dungeoneer.editor.Editor;
 import com.interrupt.dungeoneer.editor.history.EditorHistory;
@@ -288,6 +289,9 @@ public class EditorFile {
                     showWarningDialog("Unkown extension. Cannot load '" + name + "'.");
                     return;
                 }
+            } catch (SerializationException exception) {
+                showWarningDialog("Corrupted file data. Cannot load '" + file.name() + "'.");
+                return;
             } catch (Exception exception) {
                 showWarningDialog(exception.getMessage() + " Cannot load '" + file.name() + "'.");
                 return;

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/WarningDialog.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/WarningDialog.java
@@ -1,0 +1,18 @@
+package com.interrupt.dungeoneer.editor.ui;
+
+import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+
+public class WarningDialog extends Dialog {
+    public WarningDialog(Skin skin, String warning) {
+        super("Warning", skin);
+
+        text(warning);
+        getContentTable().row();
+
+        button("Understood", true);
+    }
+
+    @Override
+    protected void result(Object object) { }
+}

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/WarningDialog.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/WarningDialog.java
@@ -10,7 +10,7 @@ public class WarningDialog extends Dialog {
         text(warning);
         getContentTable().row();
 
-        button("Understood", true);
+        button("Close", true);
     }
 
     @Override


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/13063023/96375323-ae1fcf00-1178-11eb-82c2-0acf4466c74d.png)

Fixes #79.

Adds
- Editor title only updated when level successfully loaded
- Warning dialog when invalid extension
- Warning dialog when non-existing file
- Warning dialog when unsuccessful level load (e.g. invalid level data)
- Simplified loading logic when handling different file types
