### PR TITLE
Fix Models Inside of Group Not Rendering Correctly In Editor

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Group.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Group.java
@@ -28,7 +28,7 @@ public class Group extends DirectionalEntity {
 			e.tick(level, delta);
 		}
 	}
-	
+
 	@Override
 	public void init(Level level, Source source) {
 
@@ -37,7 +37,7 @@ public class Group extends DirectionalEntity {
 
         setPosition(x, y, z);
 
-		if(source != Source.EDITOR && isActive) {
+		if(source != Source.EDITOR) {
 			if(!lastRot.equals(rotation)) {
 				float remainder = (rotation.z % 90) - rotation.z;
 				int rotate90Mod = (int) (remainder / 90) % 4;
@@ -87,6 +87,11 @@ public class Group extends DirectionalEntity {
 
             lastRot.set(rotation);
 			isActive = false;
+		}
+		else {
+			for (Entity e : entities) {
+				e.init(level, source);
+			}
 		}
 	}
 


### PR DESCRIPTION
# Summary
The fix was to make sure we are initializing the entities contained in a group in an editor context.
Fixes #146 