### PR TITLE
Fixing cases where monsters with custom projectiles could shoot themselves

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/projectiles/Projectile.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/projectiles/Projectile.java
@@ -22,8 +22,6 @@ public class Projectile extends Entity {
 	/** Projectile speed.  */
 	public float speed = 0.3f;
 
-	public transient Entity owner = null;
-
 	/** Damage amount. */
 	public int damage = 3;
 


### PR DESCRIPTION
There's already a `public transient Entity owner;` in the parent Entity class, this was just shadowing that and causing the Monster to not set the owner properly.