### PR TITLE
Make halo configurable for MagicMissileProjectile

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/projectiles/MagicMissileProjectile.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/projectiles/MagicMissileProjectile.java
@@ -68,6 +68,8 @@ public class MagicMissileProjectile extends Projectile {
 	/** Projectile sprite animation speed. */
 	@EditorProperty
 	public Float animSpeed = 30f;
+
+	public HaloMode haloMode = HaloMode.BOTH;
 	
 	public MagicMissileProjectile() {
 		artType = ArtType.sprite;
@@ -227,6 +229,10 @@ public class MagicMissileProjectile extends Projectile {
 
 	@Override
 	public HaloMode getHaloMode() {
+		if (haloMode != null) {
+			return haloMode;
+		}
+
 		return HaloMode.BOTH;
 	}
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/projectiles/MagicMissileProjectile.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/projectiles/MagicMissileProjectile.java
@@ -69,6 +69,7 @@ public class MagicMissileProjectile extends Projectile {
 	@EditorProperty
 	public Float animSpeed = 30f;
 
+	/** Projectile halo type. */
 	public HaloMode haloMode = HaloMode.BOTH;
 	
 	public MagicMissileProjectile() {

--- a/jsonschema/current/dungeoneer/entities/projectiles/MagicMissileProjectile.schema.json
+++ b/jsonschema/current/dungeoneer/entities/projectiles/MagicMissileProjectile.schema.json
@@ -104,6 +104,7 @@
         "haloMode": {
             "$ref": "../Entity.schema.json#/definitions/HaloMode",
             "description": "Projectile halo type.",
+            "baseClass": "MagicMissileProjectile",
             "default": "BOTH"
         },
         "speed": {

--- a/jsonschema/current/dungeoneer/entities/projectiles/MagicMissileProjectile.schema.json
+++ b/jsonschema/current/dungeoneer/entities/projectiles/MagicMissileProjectile.schema.json
@@ -101,6 +101,11 @@
             "baseClass": "MagicMissileProjectile",
             "default": 30
         },
+        "haloMode": {
+            "$ref": "../Entity.schema.json#/definitions/HaloMode",
+            "description": "Projectile halo type.",
+            "default": "BOTH"
+        },
         "speed": {
             "type": "number",
             "description": "Projectile speed.",


### PR DESCRIPTION
# Summary
Adds a new field `haloMode` for configuring projectile's halo.