### PR TITLE
Fix Positioning Entities with Attachments in Editor

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/AnimatedSprite.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/AnimatedSprite.java
@@ -28,7 +28,11 @@ public class AnimatedSprite extends Sprite {
 		playAnimation();
 	}
 	
-	public void editorTick(Level level, float delta) { if(animation != null) animation.animate(delta, this); }
+	public void editorTick(Level level, float delta) {
+		super.editorTick(level, delta);
+		if(animation != null) animation.animate(delta, this);
+	}
+
 	public void editorStartPreview(Level level) { if(endAnimTex > 0) this.playAnimation(new SpriteAnimation(tex, endAnimTex, animSpeed, null), true); }
 	public void editorStopPreview(Level level) {
 		if(animation != null) { 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/DynamicLight.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/DynamicLight.java
@@ -175,6 +175,7 @@ public class DynamicLight extends Entity {
 
 	@Override
 	public void editorTick(Level level, float delta) {
+		super.editorTick(level, delta);
 		tick(level, delta);
 	}
 	

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Entity.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Entity.java
@@ -590,6 +590,7 @@ public class Entity {
 				attachment.owner = this;
 				attachment.isSolid = false;	// attachments are always non solid
 				attachment.tick(level, delta);
+				attachment.tickAttached(level, delta);
 
 				if(!attachment.isActive) attachedToRemove.add(attachment);
 			}
@@ -653,7 +654,29 @@ public class Entity {
 	}
 
 	// only called in the editor
-	public void editorTick(Level level, float delta) { }
+	public void editorTick(Level level, float delta) {
+		if (attached == null) {
+			return;
+		}
+
+		if (attachmentTransform == null) {
+			attachmentTransform = new Vector3();
+		}
+
+		for (Entity entity : attached) {
+			if (entity == null) {
+				continue;
+			}
+
+			entity.x += x - attachmentTransform.x;
+			entity.y += y - attachmentTransform.y;
+			entity.z += z - attachmentTransform.z;
+
+			entity.editorTick(level, delta);
+		}
+
+		attachmentTransform.set(x, y ,z);
+	}
 	public void editorStartPreview(Level level) { }
 	public void editorStopPreview(Level level) { }
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Monster.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Monster.java
@@ -1426,6 +1426,8 @@ public class Monster extends Actor implements Directional {
 
 	@Override
 	public void editorTick(Level level, float delta) {
+		super.editorTick(level, delta);
+
 		if(walkAnimation == null)
 			return;
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Particle.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Particle.java
@@ -1,7 +1,5 @@
 package com.interrupt.dungeoneer.entities;
 
-import java.util.Random;
-
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Interpolation;
 import com.badlogic.gdx.math.Vector2;
@@ -12,6 +10,8 @@ import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.game.Level.Source;
 import com.interrupt.dungeoneer.gfx.animation.SpriteAnimation;
 import com.noise.PerlinNoise;
+
+import java.util.Random;
 
 public class Particle extends Sprite {
 	public float lifetime = 82;
@@ -284,6 +284,7 @@ public class Particle extends Sprite {
 	}
 	
 	public void editorTick(Level level, float delta) {
+		super.editorTick(level, delta);
 		tick(level, delta);
 	}
 	

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/ParticleEmitter.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/ParticleEmitter.java
@@ -3,15 +3,12 @@ package com.interrupt.dungeoneer.entities;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.math.Vector3;
-import com.badlogic.gdx.math.collision.BoundingBox;
-import com.badlogic.gdx.utils.Array;
 import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.annotations.EditorProperty;
 import com.interrupt.dungeoneer.game.CachePools;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.game.Level.Source;
-import com.interrupt.dungeoneer.gfx.GlRenderer;
 import com.interrupt.dungeoneer.serializers.hacks.BoundingBoxOld;
 
 public class ParticleEmitter extends Entity {
@@ -272,6 +269,8 @@ public class ParticleEmitter extends Entity {
 	
 	@Override
 	public void editorTick(Level level, float delta) {
+		super.editorTick(level, delta);
+
 		// let the emitter make particles in the editor, just don't save them ever
 		Boolean persistValue = particlesPersist;
 		

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Torch.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Torch.java
@@ -1,15 +1,9 @@
 package com.interrupt.dungeoneer.entities;
 
-import java.util.Random;
-
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.math.Vector3;
 import com.interrupt.dungeoneer.annotations.EditorProperty;
-import com.interrupt.dungeoneer.entities.DynamicLight.LightType;
-import com.interrupt.dungeoneer.game.CachePools;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Level;
-import com.interrupt.dungeoneer.game.Options;
 import com.interrupt.dungeoneer.game.Level.Source;
 import com.interrupt.dungeoneer.gfx.animation.SpriteAnimation;
 import com.interrupt.managers.EntityManager;
@@ -136,7 +130,11 @@ public class Torch extends Light {
 		}
 	}
 
-	public void editorTick(Level level, float delta) { if(animation != null) animation.animate(delta, this); }
+	public void editorTick(Level level, float delta) {
+		super.editorTick(level, delta);
+		if(animation != null) animation.animate(delta, this);
+	}
+
 	public void editorStartPreview(Level level) { if(torchAnimateMode == TorchAnimateModes.LOOP) this.playAnimation(new SpriteAnimation(texAnimStart, texAnimEnd, animSpeed, null), true, true); }
 	public void editorStopPreview(Level level) {
 		if(animation != null) {


### PR DESCRIPTION
![delver-engine-attached](https://user-images.githubusercontent.com/372642/96931360-06551a80-1472-11eb-9710-4c72c6cf6689.gif)

# Summary

Allows attached items to keep their relative positions when being moved in editor. Also attachments will tick their attachments. Previously it would only go one level deep.