### PR TITLE
Giving drawable sprites a way to use the old method of scaling, from the center of the cut sprite

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Particle.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Particle.java
@@ -11,14 +11,13 @@ import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.game.Level.Source;
 import com.interrupt.dungeoneer.gfx.animation.SpriteAnimation;
+import com.interrupt.dungeoneer.gfx.drawables.DrawableSprite;
 import com.noise.PerlinNoise;
 
 public class Particle extends Sprite {
 	public float lifetime = 82;
 	public float starttime = 0;
 	public boolean initialized = true;
-
-    public Particle() { color = new Color(Color.WHITE); collidesWith = CollidesWith.staticOnly; }
 	
 	public boolean checkCollision = true;
 	
@@ -51,49 +50,23 @@ public class Particle extends Sprite {
 	public boolean hasHalo = false;
 
 	public HaloMode haloMode = HaloMode.NONE;
-	
-	public Particle(float x, float y, int tex)
-	{
-		super(x, y, tex);
-		artType = ArtType.particle;
 
-		lifetime = 20 + r.nextInt(160);
-		
-		isSolid = false;
-	}
-	
-	public Particle(float x, float y, float z, int tex)
-	{
-		super(x, y, tex);
-		this.z = z;
+	public Particle() {
+		color = new Color(Color.WHITE);
 		artType = ArtType.particle;
+		collidesWith = CollidesWith.staticOnly;
 
-		lifetime = 20 + r.nextInt(160);
-		
-		isSolid = false;
-	}
-	
-	public Particle(float x, float y, float z, float xv, float yv, float zv, int tex, Color c)
-	{
-		super(x, y, tex);
-		this.z = z;
-		artType = ArtType.particle;
-		
-		this.xa = xv * 2;
-		this.ya = yv * 2;
-		this.za = zv * 2;
-
-		lifetime = 20 + r.nextInt(160);
-		
-		color = new Color(c);
-		
-		isSolid = false;
+		// Create a drawable sprite that scales from the center
+		drawable = new DrawableSprite(tex, artType, false);
 	}
 	
 	public Particle(float x, float y, float z, float xv, float yv, float zv, int tex, Color c, boolean fullbrite)
 	{
-		super(x, y, tex);
+		this.x = x;
+		this.y = y;
 		this.z = z;
+
+		this.tex = tex;
 		artType = ArtType.particle;
 		
 		this.xa = xv * 2;
@@ -106,6 +79,9 @@ public class Particle extends Sprite {
 		
 		isSolid = false;
 		this.fullbrite = fullbrite;
+
+		// Create a drawable sprite that scales from the center
+		drawable = new DrawableSprite(tex, artType, false);
 	}
 	
 	@Override

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2381,7 +2381,10 @@ public class GlRenderer {
 		}
 
 		if(drawable.billboard) {
-			sd.setY(-((offset.y * atlas.scale * drawable.scale) + atlas.y_offset) + z + drawable.drawOffset.z);
+			if(drawable.scaleWithOffsets)
+				sd.setY(-((offset.y * atlas.scale * drawable.scale) + atlas.y_offset) + z + drawable.drawOffset.z);
+			else
+				sd.setY(-((offset.y) + atlas.y_offset) + z + drawable.drawOffset.z);
 		}
 		else {
 			sd.setY(z + drawable.drawOffset.z);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2381,7 +2381,7 @@ public class GlRenderer {
 		}
 
 		if(drawable.billboard) {
-			sd.setY(-(offset.y + atlas.y_offset) + z + drawable.drawOffset.z);
+			sd.setY(-((offset.y * atlas.scale * drawable.scale) + atlas.y_offset) + z + drawable.drawOffset.z);
 		}
 		else {
 			sd.setY(z + drawable.drawOffset.z);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/drawables/DrawableSprite.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/drawables/DrawableSprite.java
@@ -18,6 +18,7 @@ public class DrawableSprite extends Drawable {
 	public Float cameraPull = null;
 	public boolean isFogSprite = false;
 	public transient Color colorLastFrame = null;
+	public boolean scaleWithOffsets = true;
 	
 	public Vector3 rotation = Vector3.Zero;
 	public float xScale = 1;
@@ -30,16 +31,11 @@ public class DrawableSprite extends Drawable {
 		this.tex = tex;
 		this.artType = artType;
 	}
-	
-	public DrawableSprite(int tex, ArtType artType, float rot) {
+
+	public DrawableSprite(int tex, ArtType artType, boolean scaleWithOffsets) {
 		this.tex = tex;
 		this.artType = artType;
-		this.rot = rot;
-	}
-
-	public DrawableSprite(int tex, TextureAtlas spriteAtlas) {
-		this.tex = tex;
-		this.atlas = spriteAtlas;
+		this.scaleWithOffsets = scaleWithOffsets;
 	}
 	
 	public void update(Entity e) {


### PR DESCRIPTION
Particles now use this scaling method by default, as they relied on that behavior.