### PR TITLE
Fixing re-generate menu items not working

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -448,10 +448,7 @@ public class EditorApplication implements ApplicationListener {
 
 	/** Generates a level based on a `template` level. */
 	public void generateLevelFromTemplate(Level template) {
-		level.editorMarkers.clear();
-		level.entities.clear();
-		level.non_collidable_entities.clear();
-		level.static_entities.clear();
+		level.clear();
 
 		level.theme = template.theme;
 		level.generated = true;

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -55,6 +55,7 @@ import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.game.Level.Source;
 import com.interrupt.dungeoneer.generator.DungeonGenerator;
+import com.interrupt.dungeoneer.generator.GenTheme;
 import com.interrupt.dungeoneer.generator.RoomGenerator;
 import com.interrupt.dungeoneer.generator.GenInfo.Markers;
 import com.interrupt.dungeoneer.gfx.GlRenderer;
@@ -454,7 +455,12 @@ public class EditorApplication implements ApplicationListener {
 		level.theme = template.theme;
 		level.generated = true;
 		level.dungeonLevel = 0;
-		level.crop(0, 0, 17 * 5, 17 * 5);
+
+		GenTheme genTheme = DungeonGenerator.GetGenData(template.theme);
+		int chunkTiles = genTheme.getChunkTileSize();
+		int mapChunks = genTheme.getMapChunks();
+		level.crop(0, 0, chunkTiles * mapChunks, chunkTiles * mapChunks);
+
 		level.roomGeneratorChance = template.roomGeneratorChance;
 		level.roomGeneratorType = template.roomGeneratorType;
 		level.generate(Level.Source.EDITOR);
@@ -464,12 +470,12 @@ public class EditorApplication implements ApplicationListener {
 
 	/** Generates a single room based on a `template` level. */
 	public void generateRoomFromTemplate(Level template) {
-		level.editorMarkers.clear();
-		level.entities.clear();
-		level.non_collidable_entities.clear();
-		level.static_entities.clear();
+		level.clear();
 
-		Level generatedLevel = new Level(17, 17);
+		GenTheme genTheme = DungeonGenerator.GetGenData(template.theme);
+		int chunkTiles = genTheme.getChunkTileSize();
+		Level generatedLevel = new Level(chunkTiles, chunkTiles);
+
 		generatedLevel.roomGeneratorType = template.roomGeneratorType;
 
 		RoomGenerator generator = new RoomGenerator(generatedLevel, template.roomGeneratorType);

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -455,7 +455,7 @@ public class EditorApplication implements ApplicationListener {
 		level.generated = true;
 		level.dungeonLevel = 0;
 		level.crop(0, 0, 17 * 5, 17 * 5);
-		level.roomGeneratorChance = 0.4f;
+		level.roomGeneratorChance = template.roomGeneratorChance;
 		level.roomGeneratorType = template.roomGeneratorType;
 		level.generate(Level.Source.EDITOR);
 

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -444,6 +444,7 @@ public class EditorApplication implements ApplicationListener {
 		level.setTile(width / 2, height / 2, t);
 
 		cleanEditorState();
+		cameraController.setDefaultPositionAndRotation();
 	}
 
 	/** Generates a level based on a `template` level. */
@@ -491,8 +492,6 @@ public class EditorApplication implements ApplicationListener {
 
 		history.saveState(level);
 		file.markClean();
-
-		cameraController.setDefaultPositionAndRotation();
 	}
 
 	@Override

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/LevelGeneratorMenuItem.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/LevelGeneratorMenuItem.java
@@ -90,27 +90,11 @@ public class LevelGeneratorMenuItem extends DynamicMenuItem {
                                 warningDialog.show(Editor.app.ui.getStage());
                             }
                             else {
-                                Level level = Editor.app.getLevel();
-    
-                                if (level != null) {
-                                    level.editorMarkers.clear();
-                                    level.entities.clear();
-                                    level.non_collidable_entities.clear();
-                                    level.static_entities.clear();
-    
-                                    level.theme = template.theme;
-                                    level.generated = true;
-                                    level.dungeonLevel = 0;
-                                    level.crop(0, 0, 17 * 5, 17 * 5);
-                                    level.roomGeneratorChance = 0.4f;
-                                    level.roomGeneratorType = template.roomGeneratorType;
-                                    level.generate(Level.Source.EDITOR);
-                                    Editor.app.refresh();
-    
-                                    if (Editor.app.generatorInfo.isLastGeneratedLevelTemplateSelected(template)) {
-                                        Editor.app.generatorInfo.lastGeneratedLevelTemplate = template;
-                                        needsRefresh = true;
-                                    }
+                                Editor.app.generateLevelFromTemplate(template);
+
+                                if (!Editor.app.generatorInfo.isLastGeneratedLevelTemplateSelected(template)) {
+                                    Editor.app.generatorInfo.lastGeneratedLevelTemplate = template;
+                                    needsRefresh = true;
                                 }
                             }
                         }

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/RoomGeneratorMenuItem.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/RoomGeneratorMenuItem.java
@@ -91,24 +91,9 @@ public class RoomGeneratorMenuItem extends DynamicMenuItem {
                                 warningDialog.show(Editor.app.ui.getStage());
                             }
                             else {
-                                Editor.app.getLevel().editorMarkers.clear();
-                                Editor.app.getLevel().entities.clear();
-                                Editor.app.getLevel().non_collidable_entities.clear();
-                                Editor.app.getLevel().static_entities.clear();
+                                Editor.app.generateRoomFromTemplate(template);
     
-                                Level generatedLevel = new Level(17, 17);
-                                generatedLevel.roomGeneratorType = template.roomGeneratorType;
-    
-                                RoomGenerator generator = new RoomGenerator(generatedLevel, template.roomGeneratorType);
-                                generator.generate(true, true, true, true);
-    
-                                Editor.app.getLevel().crop(0, 0, generatedLevel.width, generatedLevel.height);
-                                Editor.app.getLevel().paste(generatedLevel, 0, 0);
-                                Editor.app.getLevel().theme = template.theme;
-    
-                                Editor.app.refresh();
-    
-                                if (Editor.app.generatorInfo.isLastGeneratedRoomTemplateSelected(template)) {
+                                if (!Editor.app.generatorInfo.isLastGeneratedRoomTemplateSelected(template)) {
                                     Editor.app.generatorInfo.lastGeneratedRoomTemplate = template;
                                     needsRefresh = true;
                                 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
@@ -3761,4 +3761,11 @@ public class Level {
 		if(ambientSound != null && !Game.isMobile)
 			Audio.playAmbientSound(ambientSound, Game.instance.level.ambientSoundVolume, 0.1f);
 	}
+
+	public void clear() {
+		if (editorMarkers != null) editorMarkers.clear();
+		if (entities != null) entities.clear();
+		if (static_entities != null) static_entities.clear();
+		if (non_collidable_entities != null) non_collidable_entities.clear();
+	}
 }


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/13063023/98388643-4fe95c00-2053-11eb-88ba-88df826665d0.png)

## Summary
Refactored level generation in the editor, in order to align new level creation with level and room generations (editor state, camera position, save file) and fixed a bug where the re-generate menu items for level and room were using an inversed logic.