### PR TITLE
NPC/Group Entities Not Showing In Editor

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -168,6 +168,7 @@ public class Game {
 		EntityManager.setSingleton(entityManager);
 	}
 	
+	/** Create game for editor usage. */
 	public Game(Level levelToStart) {
 		instance = this;
 		level = levelToStart;
@@ -186,9 +187,6 @@ public class Game {
 		
 		bag.visible = false;
 		
-		// Load the levels data file, keep the levels array null for now (try loading from save first)
-		level = levelToStart;
-
 		// Load the base game data
 		if(gameData == null) {
 			gameData = modManager.loadGameData();

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
@@ -313,7 +313,7 @@ public class Level {
 
 			if(!copy.isDynamic)
 				copyStaticEntities.add(copy);
-			else if(!copy.isSolid && !(copy instanceof ButtonDecal))
+			else if(!copy.isSolid)
 				copyNonCollidableEntities.add(copy);
 			else
 				copyEntities.add(copy);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
@@ -306,39 +306,17 @@ public class Level {
 		Array<Entity> copyNonCollidableEntities = new Array<>(100);
 		Array<Entity> copyStaticEntities = new Array<>(100);
 
-		if ((static_entities != null && static_entities.size > 0) || (non_collidable_entities != null && non_collidable_entities.size > 0)) {
-			// We already have data for other entity types, therefore, we do not need to split the entities again (generated level).
-			for(int i = 0; i < entities.size; i++) {
-				Entity copy = entities.get(i);
-				if(!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance)) continue;
-				copyEntities.add(copy);
-			}
+		for(int i = 0; i < entities.size; i++) {
+			Entity copy = entities.get(i);
+			if (!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance))
+				continue;
 
-			for(int i = 0; i < non_collidable_entities.size; i++) {
-				Entity copy = non_collidable_entities.get(i);
-				if(!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance)) continue;
-				copyNonCollidableEntities.add(copy);
-			}
-
-			for(int i = 0; i < static_entities.size; i++) {
-				Entity copy = static_entities.get(i);
-				if(!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance)) continue;
+			if(!copy.isDynamic)
 				copyStaticEntities.add(copy);
-			}
-		}
-		else {
-			// We need to split the entities into their respective types (loaded level).
-			for(int i = 0; i < entities.size; i++) {
-				Entity copy = entities.get(i);
-				if(!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance)) continue;
-					
-				if(!copy.isDynamic)
-					copyStaticEntities.add(copy);
-				else if(!copy.isSolid && !(copy instanceof ButtonDecal))
-					copyNonCollidableEntities.add(copy);
-				else
-					copyEntities.add(copy);
-			}
+			else if(!copy.isSolid && !(copy instanceof ButtonDecal))
+				copyNonCollidableEntities.add(copy);
+			else
+				copyEntities.add(copy);
 		}
 		
 		entities = copyEntities;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
@@ -302,28 +302,28 @@ public class Level {
 		fogEnd = 20f;
 		viewDistance = 20f;
 		
-		Array<Entity> copy_entities = new Array<>(100);
-		Array<Entity> copy_non_collidable_entities = new Array<>(100);
-		Array<Entity> copy_static_entities = new Array<>(100);
+		Array<Entity> copyEntities = new Array<>(100);
+		Array<Entity> copyNonCollidableEntities = new Array<>(100);
+		Array<Entity> copyStaticEntities = new Array<>(100);
 
 		if ((static_entities != null && static_entities.size > 0) || (non_collidable_entities != null && non_collidable_entities.size > 0)) {
 			// We already have data for other entity types, therefore, we do not need to split the entities again (generated level).
 			for(int i = 0; i < entities.size; i++) {
 				Entity copy = entities.get(i);
 				if(!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance)) continue;
-				copy_entities.add(copy);
+				copyEntities.add(copy);
 			}
 
 			for(int i = 0; i < non_collidable_entities.size; i++) {
 				Entity copy = non_collidable_entities.get(i);
 				if(!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance)) continue;
-				copy_non_collidable_entities.add(copy);
+				copyNonCollidableEntities.add(copy);
 			}
 
 			for(int i = 0; i < static_entities.size; i++) {
 				Entity copy = static_entities.get(i);
 				if(!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance)) continue;
-				copy_static_entities.add(copy);
+				copyStaticEntities.add(copy);
 			}
 		}
 		else {
@@ -333,17 +333,17 @@ public class Level {
 				if(!copy.checkDetailLevel() || (copy.spawnChance < 1f && Game.rand.nextFloat() > copy.spawnChance)) continue;
 					
 				if(!copy.isDynamic)
-					copy_static_entities.add(copy);
+					copyStaticEntities.add(copy);
 				else if(!copy.isSolid && !(copy instanceof ButtonDecal))
-					copy_non_collidable_entities.add(copy);
+					copyNonCollidableEntities.add(copy);
 				else
-					copy_entities.add(copy);
+					copyEntities.add(copy);
 			}
 		}
 		
-		entities = copy_entities;
-		non_collidable_entities = copy_non_collidable_entities;
-		static_entities = copy_static_entities;
+		entities = copyEntities;
+		non_collidable_entities = copyNonCollidableEntities;
+		static_entities = copyStaticEntities;
 
 		genTheme = DungeonGenerator.GetGenData(theme);
 
@@ -351,7 +351,7 @@ public class Level {
 
 		initPrefabs();
 
-		addEntitiesFromMarkers(editorMarkers, new Array<Vector2>(), new Boolean[width * height], new Array<Vector2>(), genTheme, 0, 0);
+		addEntitiesFromMarkers(editorMarkers, new Array<>(), new Boolean[width * height], new Array<>(), genTheme, 0, 0);
 		decorateLevel();
 
 		init(Source.LEVEL_START);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
@@ -349,7 +349,7 @@ public class Level {
 
 		loadSurprises(genTheme);
 
-		initPrefabs();
+		initPrefabs(Source.LEVEL_START);
 
 		addEntitiesFromMarkers(editorMarkers, new Array<>(), new Boolean[width * height], new Array<>(), genTheme, 0, 0);
 		decorateLevel();
@@ -428,7 +428,7 @@ public class Level {
 		// mark some locations as trap-free
 		Array<Vector2> trapAvoidLocs = new Array<Vector2>();
 
-		initPrefabs();
+		initPrefabs(Source.EDITOR);
 
 		// keep a list of places to avoid when making traps
 		Boolean canMakeTrap[] = new Boolean[width * height];
@@ -668,7 +668,7 @@ public class Level {
 		// mark some locations as trap-free
 		Array<Vector2> trapAvoidLocs = new Array<Vector2>();
 
-		initPrefabs();
+		initPrefabs(Source.LEVEL_START);
 		
 		decorateLevel();
 		
@@ -1542,26 +1542,26 @@ public class Level {
 		return false;
 	}
 
-	public void initPrefabs() {
+	public void initPrefabs(Source source) {
 		// init any prefabs
 		// this is a separate pass as things like Monsters might want to check their collisions!
 
 		for(int i = 0; i < entities.size; i++) {
 			Entity e = entities.get(i);
 			if(e instanceof Group) {
-				e.init(this, Source.LEVEL_START);
+				e.init(this, source);
 			}
 		}
 		for(int i = 0; i < non_collidable_entities.size; i++) {
 			Entity e = non_collidable_entities.get(i);
 			if(e instanceof Group) {
-				e.init(this, Source.LEVEL_START);
+				e.init(this, source);
 			}
 		}
 		for(int i = 0; i < static_entities.size; i++) {
 			Entity e = static_entities.get(i);
 			if(e instanceof Group) {
-				e.init(this, Source.LEVEL_START);
+				e.init(this, source);
 			}
 		}
 


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/13063023/98389117-ed449000-2053-11eb-997b-39179376b6d0.png)

## Summary
Fixes #145. Uses kind of a *hacky* approach. The problem is, that when generating a level somewhere `entities`, `static_entities` and `non_collidable_entities` are set. When loading any level for playtesting, `entities` get split into the other two categories, therefore we lose that entity information. However, when loading a level from e.g. `generator` these categories are not set.
This is probably one of the first steps into fixing the differences between editor and game levels.