### PR TITLE
Use Correct API to Find Options File

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorOptions.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorOptions.java
@@ -1,8 +1,8 @@
 package com.interrupt.dungeoneer.editor;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
+import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.utils.JsonUtil;
 
 /** Editor options container class. */
@@ -14,7 +14,7 @@ public class EditorOptions {
     }
 
     public static EditorOptions fromLocalFiles() {
-	    FileHandle file = Gdx.files.local(getEditorOptionsFilePath());
+	    FileHandle file = Game.getFile(getEditorOptionsFilePath());
 
         return JsonUtil.fromJson(EditorOptions.class, file, ()-> {
             EditorOptions eo = new EditorOptions();
@@ -24,7 +24,8 @@ public class EditorOptions {
     }
 
     public static void toLocalFiles(EditorOptions instance) {
-        JsonUtil.toJson(instance, getEditorOptionsFilePath());
+        FileHandle file = Game.getFile(getEditorOptionsFilePath());
+        JsonUtil.toJson(instance, file);
     }
 
     public void save() {
@@ -36,7 +37,7 @@ public class EditorOptions {
     }
 
     public static String getEditorOptionsFilePath() {
-        return "/save/editor.txt";
+        return "save/editor.txt";
     }
 
     public void removeRecentlyOpenedFile(String path) {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Options.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Options.java
@@ -167,7 +167,7 @@ public class Options {
 
     /** Load options from file and update instance. */
     public static void loadOptions() {
-        FileHandle file = Gdx.files.local(getOptionsFilePath());
+        FileHandle file = Game.getFile(getOptionsFilePath());
 
         instance = JsonUtil.fromJson(Options.class, file, () -> {
             Options o = new Options(Gdx.app.getType());
@@ -183,7 +183,8 @@ public class Options {
         }
 
         try {
-            JsonUtil.toJson(instance, getOptionsFilePath());
+            FileHandle file = Game.getFile(getOptionsFilePath());
+            JsonUtil.toJson(instance, file);
         }
         catch (Exception e) {
             Gdx.app.log("Delver", "Failed to save options file.");

--- a/Dungeoneer/src/com/interrupt/utils/JsonUtil.java
+++ b/Dungeoneer/src/com/interrupt/utils/JsonUtil.java
@@ -9,12 +9,6 @@ import java.util.function.Supplier;
 
 /** Helper class for working with JSON. */
 public class JsonUtil {
-    /** Serializes the given object to the specified path. */
-    public static void toJson(Object object, String path) {
-        FileHandle file = Gdx.files.local(path);
-        toJson(object, file);
-    }
-
     /** Serializes the given object to the given file. */
     public static void toJson(Object object, FileHandle file) {
         if (file == null) {


### PR DESCRIPTION
# Summary
Fixes the following issues:

- Options class was using incorrect API to get the options.txt file and was trying read/write to internal files.
- EditorOptions class was using incorrect path and writing to root of volume.