### PR TITLE
Simplifying the dist task

### DIFF
--- a/DelvEdit/build.gradle
+++ b/DelvEdit/build.gradle
@@ -27,6 +27,8 @@ task dist(type: Jar) {
     manifest {
         attributes 'Main-Class': project.mainClassName
     }
+
+    dependsOn 'processResources'
     dependsOn configurations.runtimeClasspath
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }

--- a/DungeoneerDesktop/build.gradle
+++ b/DungeoneerDesktop/build.gradle
@@ -27,6 +27,8 @@ task dist(type: Jar) {
     manifest {
         attributes 'Main-Class': project.mainClassName
     }
+
+    dependsOn 'processResources'
     dependsOn configurations.runtimeClasspath
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }


### PR DESCRIPTION
# Summary
Makes the `processResources` task a dependency of the `dist` task to simplify the build process.