### PR TITLE
Load Options File Before Starting App

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/EditorStarter.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/EditorStarter.java
@@ -4,23 +4,25 @@ import com.interrupt.api.steam.NullSteamApi;
 import com.interrupt.api.steam.SteamApi;
 import com.interrupt.dungeoneer.editor.Editor;
 import com.interrupt.dungeoneer.game.ModManager;
+import com.interrupt.dungeoneer.game.Options;
 import com.interrupt.dungeoneer.scripting.ScriptLoader;
 
 public class EditorStarter {
-	public static void main(String[] args) {
+    public static void main(String[] args) {
         System.setProperty("com.apple.mrj.application.apple.menu.about.name", "DelvEdit");
+        Options.loadOptions();
         Editor.init();
 
         // Start the null steam API
         SteamApi.api = new NullSteamApi();
         SteamApi.api.init();
 
-        if(args != null) {
+        if (args != null) {
             for (String arg : args) {
-                if(arg.toLowerCase().endsWith("enable-mod-classes=true")) {
+                if (arg.toLowerCase().endsWith("enable-mod-classes=true")) {
                     ModManager.setScriptingApi(new ScriptLoader());
                 }
             }
         }
-	}
+    }
 }

--- a/DelvEdit/src/com/interrupt/dungeoneer/EditorStarter.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/EditorStarter.java
@@ -9,8 +9,10 @@ import com.interrupt.dungeoneer.scripting.ScriptLoader;
 
 public class EditorStarter {
     public static void main(String[] args) {
-        System.setProperty("com.apple.mrj.application.apple.menu.about.name", "DelvEdit");
+        // We must call this first to get the correct display options
         Options.loadOptions();
+        
+        System.setProperty("com.apple.mrj.application.apple.menu.about.name", "DelvEdit");
         Editor.init();
 
         // Start the null steam API

--- a/Dungeoneer/src/com/interrupt/dungeoneer/GameApplication.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/GameApplication.java
@@ -38,7 +38,6 @@ public class GameApplication extends Game {
 		gameManager = new GameManager(this);
         Gdx.input.setInputProcessor( input );
         gameManager.init();
-        Options.loadOptions();
 
         mainMenuScreen = new SplashScreen();
         mainScreen = new GameScreen(gameManager, input);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/GameApplication.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/GameApplication.java
@@ -55,7 +55,6 @@ public class GameApplication extends Game {
 		gameManager = new GameManager(this);
         Gdx.input.setInputProcessor( input );
         gameManager.init();
-        Options.loadOptions();
 
 		com.interrupt.dungeoneer.game.Game.inEditor = true;
         mainMenuScreen = new SplashScreen();

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -1116,24 +1116,25 @@ public class Game {
 		player.saveVersion = SAVE_VERSION;
 	}
 
-	public static FileHandle getFile(String file)
-	{
-		if(Gdx.app.getType() != ApplicationType.Android && Gdx.app.getType() != ApplicationType.iOS) {
+    public static FileHandle getFile(String file) {
+        if (OSUtils.isMac()) {
+            // OSX needs this user.dir property to figure out where it is running from, and probably linux
+            String userDir = System.getProperty("user.dir");
+            if (userDir != null) {
+                return new FileHandle(userDir + "/" + file);
+            }
+        }
 
-			if(OSUtils.isMac()) {
-				// OSX needs this user.dir property to figure out where it is running from, and probably linux
-				String userDir = System.getProperty("user.dir");
-				if (userDir != null) {
-					return new FileHandle(userDir + "/" + file);
-				}
-			}
+        if (OSUtils.isMobile() && Gdx.files != null) {
+            if (Gdx.files.isExternalStorageAvailable()) {
+                return Gdx.files.external("Delver/" + file);
+            }
 
-			return new FileHandle(file);
-		}
+            return Gdx.files.local("Delver/" + file);
+        }
 
-		if(Gdx.files.isExternalStorageAvailable()) return Gdx.files.external("Delver/" + file);
-		return Gdx.files.local("Delver/" + file);
-	}
+        return new FileHandle(file);
+    }
 
 	public static Level GetLevel()
 	{

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Options.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Options.java
@@ -1,6 +1,5 @@
 package com.interrupt.dungeoneer.game;
 
-import com.badlogic.gdx.Application.ApplicationType;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.files.FileHandle;
@@ -9,6 +8,7 @@ import com.interrupt.dungeoneer.input.Actions.Action;
 import com.interrupt.dungeoneer.input.GamepadBinding;
 import com.interrupt.dungeoneer.input.GamepadDefinition;
 import com.interrupt.utils.JsonUtil;
+import com.interrupt.utils.OSUtils;
 
 /** Game options container class. */
 public class Options {
@@ -89,17 +89,14 @@ public class Options {
         instance = new Options();
     }
 
-    public Options() { }
-
-    public Options(ApplicationType applicationType) {
-        if (applicationType == ApplicationType.Android || applicationType == ApplicationType.iOS) {
+    public Options() {
+        if (OSUtils.isMobile()) {
             graphicsDetailLevel = 2;
             shadowsEnabled = false;
             postProcessingQuality = 0;
             fxaaEnabled = false;
         }
     }
-
 
     public static void SetInputOptions(GamepadDefinition defaultGamepad) {
         Actions.keyBindings.put(Action.USE, Options.instance.key_use);
@@ -170,7 +167,7 @@ public class Options {
         FileHandle file = Game.getFile(getOptionsFilePath());
 
         instance = JsonUtil.fromJson(Options.class, file, () -> {
-            Options o = new Options(Gdx.app.getType());
+            Options o = new Options();
             JsonUtil.toJson(o, file);
             return o;
         });

--- a/Dungeoneer/src/com/interrupt/utils/JsonUtil.java
+++ b/Dungeoneer/src/com/interrupt/utils/JsonUtil.java
@@ -12,7 +12,7 @@ public class JsonUtil {
     /** Serializes the given object to the given file. */
     public static void toJson(Object object, FileHandle file) {
         if (file == null) {
-            Gdx.app.log("Serialization", "Attempting to write to a null FileHandle object.");
+            log("Serialization", "Attempting to write to a null FileHandle object.");
             return;
         }
 
@@ -42,7 +42,7 @@ public class JsonUtil {
             contents = contents.replace("\t", "    ");
         }
         catch (Exception ignored) {
-            Gdx.app.log("Serialization", "Failed to serialize object.");
+            log("Serialization", "Failed to serialize object.");
         }
 
         return contents;
@@ -63,7 +63,7 @@ public class JsonUtil {
         catch (Exception ignored) { }
 
         if (result == null) {
-            Gdx.app.log("Serialization", String.format("Warning: Failed to deserialize file: \"%s\". Using default value.", file.toString()));
+            log("Serialization", String.format("Warning: Failed to deserialize file: \"%s\". Using default value.", file.toString()));
             result = defaultValueSupplier.get();
         }
 
@@ -79,7 +79,7 @@ public class JsonUtil {
             result = json_.fromJson(type, json);
         }
         catch (Exception ex) {
-            Gdx.app.log("Serialization", String.format("Error: Failed to deserialize JSON: \"%s\"", json));
+            log("Serialization", String.format("Error: Failed to deserialize JSON: \"%s\"", json));
             throw ex;
         }
 
@@ -91,7 +91,7 @@ public class JsonUtil {
         Json json = new Json() {
             @Override
             protected boolean ignoreUnknownField(Class type, String fieldName) {
-                Gdx.app.log("Serialization", String.format("Warning: Unknown field: %s for class: %s", fieldName, type));
+                log("Serialization", String.format("Warning: Unknown field: %s for class: %s", fieldName, type));
 
                 return true;
             }
@@ -99,5 +99,14 @@ public class JsonUtil {
         json.setOutputType(JsonWriter.OutputType.json);
 
         return json;
+    }
+
+    private static void log(String tag, String message) {
+        if (Gdx.app == null) {
+            System.out.println("[" + tag + "] " + message);
+            return;
+        }
+
+        Gdx.app.log(tag, message);
     }
 }

--- a/Dungeoneer/src/com/interrupt/utils/OSUtils.java
+++ b/Dungeoneer/src/com/interrupt/utils/OSUtils.java
@@ -1,26 +1,39 @@
 package com.interrupt.utils;
 
-public final class OSUtils
-{
-   private static String OS = null;
-   
-   public static String getOsName()
-   {
-      if(OS == null) {
-          OS = System.getProperty("os.name");
-          if(OS == null)
-              return "unknown";
-      }
-      return OS.toLowerCase();
-   }
-   
-   public static boolean isWindows()
-   {
-      return getOsName().startsWith("windows");
-   }
+public final class OSUtils {
+    private static String OS;
 
-   public static boolean isMac()
-   {
-       return getOsName().startsWith("mac");
-   }
+    static {
+        OS = System.getProperty("os.name");
+        if (OS == null) {
+            OS = "unknown";
+        }
+        OS = OS.toLowerCase();
+    }
+
+    public static boolean isWindows() {
+        return OS.startsWith("windows");
+    }
+
+    public static boolean isMac() {
+        return OS.startsWith("mac");
+    }
+
+    public static boolean isIOS() {
+        return OS.startsWith("ios");
+    }
+
+    public static boolean isAndroid() {
+        String vendor = System.getProperty("java.vendor").toLowerCase();
+
+        return vendor.contains("android");
+    }
+
+    public static boolean isMobile() {
+        return isAndroid() || isIOS();
+    }
+
+    public static boolean isDesktop() {
+        return !isMobile();
+    }
 }

--- a/Dungeoneer/src/com/interrupt/utils/OSUtils.java
+++ b/Dungeoneer/src/com/interrupt/utils/OSUtils.java
@@ -24,7 +24,11 @@ public final class OSUtils {
     }
 
     public static boolean isAndroid() {
-        String vendor = System.getProperty("java.vendor").toLowerCase();
+        String vendor = System.getProperty("java.vendor");
+        if (vendor == null) {
+            vendor = "unknown";
+        }
+        vendor = vendor.toLowerCase();
 
         return vendor.contains("android");
     }

--- a/DungeoneerDesktop/src/com/interrupt/dungeoneer/DesktopStarter.java
+++ b/DungeoneerDesktop/src/com/interrupt/dungeoneer/DesktopStarter.java
@@ -11,6 +11,8 @@ import com.interrupt.dungeoneer.modding.ScriptLoader;
 
 public class DesktopStarter {
     public static void main(String[] args) {
+        Options.loadOptions();
+
         DisplayMode defaultMode = LwjglApplicationConfiguration.getDesktopDisplayMode();
 
         LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();

--- a/DungeoneerDesktop/src/com/interrupt/dungeoneer/DesktopStarter.java
+++ b/DungeoneerDesktop/src/com/interrupt/dungeoneer/DesktopStarter.java
@@ -11,6 +11,7 @@ import com.interrupt.dungeoneer.modding.ScriptLoader;
 
 public class DesktopStarter {
     public static void main(String[] args) {
+        // We must call this first to get the correct display options
         Options.loadOptions();
 
         DisplayMode defaultMode = LwjglApplicationConfiguration.getDesktopDisplayMode();


### PR DESCRIPTION
## Summary
Fixes issue with game not launching with saved display options (vsync, fullscreen, etc). The issue is we need to load the options file before we launch the app. The tricky part is we need to launch the app to access the `Gdx.files` API.

### Changes
- `Options.loadOptions()` now called before anything else in app starters.
- `Game.getFile()` will work for Desktop environments without the app being initialized. For mobile devices we check if the `Gdx.files` API is available and fallback to desktop behavior if not.
- OSUtils.java was updated with methods to detect mobile environments without using Ggx.