### PR TITLE
[Editor|Feature] Making Room Exits Configurable In Editor

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -42,6 +42,7 @@ import com.interrupt.dungeoneer.editor.ui.EditorUi;
 import com.interrupt.dungeoneer.editor.ui.SaveChangesDialog;
 import com.interrupt.dungeoneer.editor.ui.TextureRegionPicker;
 import com.interrupt.dungeoneer.editor.ui.menu.generator.GeneratorInfo;
+import com.interrupt.dungeoneer.editor.ui.menu.generator.RoomGeneratorSettings;
 import com.interrupt.dungeoneer.editor.utils.LiveReload;
 import com.interrupt.dungeoneer.entities.*;
 import com.interrupt.dungeoneer.entities.Entity.ArtType;
@@ -470,7 +471,7 @@ public class EditorApplication implements ApplicationListener {
 	}
 
 	/** Generates a single room based on a `template` level. */
-	public void generateRoomFromTemplate(Level template) {
+	public void generateRoomFromTemplate(Level template, RoomGeneratorSettings roomGeneratorSettings) {
 		level.clear();
 
 		GenTheme genTheme = DungeonGenerator.GetGenData(template.theme);
@@ -480,7 +481,7 @@ public class EditorApplication implements ApplicationListener {
 		generatedLevel.roomGeneratorType = template.roomGeneratorType;
 
 		RoomGenerator generator = new RoomGenerator(generatedLevel, template.roomGeneratorType);
-		generator.generate(true, true, true, true);
+		generator.generate(roomGeneratorSettings.northExit, roomGeneratorSettings.southExit, roomGeneratorSettings.eastExit, roomGeneratorSettings.westExit);
 
 		level.crop(0, 0, generatedLevel.width, generatedLevel.height);
 		level.paste(generatedLevel, 0, 0);

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/GeneratorInfo.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/GeneratorInfo.java
@@ -20,8 +20,12 @@ public class GeneratorInfo {
     public Level lastGeneratedLevelTemplate;
     public Level lastGeneratedRoomTemplate;
 
+    public RoomGeneratorSettings roomGeneratorSettings;
+
     public GeneratorInfo() {
         refresh();
+
+        roomGeneratorSettings = new RoomGeneratorSettings();
     }
 
     public void refresh() {

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/RoomGeneratorMenuItem.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/RoomGeneratorMenuItem.java
@@ -7,13 +7,13 @@ import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.utils.Array;
 import com.interrupt.dungeoneer.editor.Editor;
+import com.interrupt.dungeoneer.editor.ui.EditorUi;
 import com.interrupt.dungeoneer.editor.ui.WarningDialog;
 import com.interrupt.dungeoneer.editor.ui.menu.DynamicMenuItem;
 import com.interrupt.dungeoneer.editor.ui.menu.DynamicMenuItemAction;
 import com.interrupt.dungeoneer.editor.ui.menu.MenuAccelerator;
 import com.interrupt.dungeoneer.editor.ui.menu.MenuItem;
 import com.interrupt.dungeoneer.game.Level;
-import com.interrupt.dungeoneer.generator.RoomGenerator;
 import com.interrupt.dungeoneer.generator.SectionDefinition;
 
 public class RoomGeneratorMenuItem extends DynamicMenuItem {
@@ -61,6 +61,9 @@ public class RoomGeneratorMenuItem extends DynamicMenuItem {
                     }
 
                     menuItem.addSeparator();
+                    menuItem.addItem(new MenuItem("Settings", skin, makeSettingsAction()));
+
+                    menuItem.addSeparator();
                     String label = "Re-Generate Room"
                             + (Editor.app.generatorInfo.lastGeneratedRoomTemplate != null
                                     ? " (" + Editor.app.generatorInfo.lastGeneratedRoomTemplate.roomGeneratorType + ", "
@@ -87,12 +90,13 @@ public class RoomGeneratorMenuItem extends DynamicMenuItem {
                     public void actionPerformed(ActionEvent actionEvent) {
                         if (template != null) {
                             if (!Editor.app.generatorInfo.isLevelTemplateValid(template)) {
-                                WarningDialog warningDialog = new WarningDialog(skin, "We were not able to find the level template used for this room generator. Make sure it exists.");
+                                WarningDialog warningDialog = new WarningDialog(skin,
+                                        "We were not able to find the level template used for this room generator. Make sure it exists.");
                                 warningDialog.show(Editor.app.ui.getStage());
-                            }
-                            else {
-                                Editor.app.generateRoomFromTemplate(template);
-    
+                            } else {
+                                Editor.app.generateRoomFromTemplate(template,
+                                        Editor.app.generatorInfo.roomGeneratorSettings);
+
                                 if (!Editor.app.generatorInfo.isLastGeneratedRoomTemplateSelected(template)) {
                                     Editor.app.generatorInfo.lastGeneratedRoomTemplate = template;
                                     needsRefresh = true;
@@ -109,6 +113,25 @@ public class RoomGeneratorMenuItem extends DynamicMenuItem {
                     public void actionPerformed(ActionEvent actionEvent) {
                         makeRoomGeneratorAction(Editor.app.generatorInfo.lastGeneratedRoomTemplate)
                                 .actionPerformed(actionEvent);
+                    }
+                };
+            }
+
+            private ActionListener makeSettingsAction() {
+                return new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        RoomGeneratorSettingsDialog dialog = new RoomGeneratorSettingsDialog(EditorUi.smallSkin,
+                                Editor.app.generatorInfo.roomGeneratorSettings) {
+                            @Override
+                            protected void result(Object object) {
+                                if ((Boolean) object) {
+                                    Editor.app.generatorInfo.roomGeneratorSettings = getSettings();
+                                }
+                            }
+                        };
+
+                        dialog.show(Editor.app.ui.getStage());
                     }
                 };
             }

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/RoomGeneratorSettings.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/RoomGeneratorSettings.java
@@ -1,0 +1,19 @@
+package com.interrupt.dungeoneer.editor.ui.menu.generator;
+
+public class RoomGeneratorSettings {
+    public boolean northExit = true;
+    public boolean eastExit = true;
+    public boolean southExit = true;
+    public boolean westExit = true;
+
+    public static RoomGeneratorSettings copy(RoomGeneratorSettings settings) {
+        RoomGeneratorSettings copiedSettings = new RoomGeneratorSettings();
+
+        copiedSettings.northExit = settings.northExit;
+        copiedSettings.eastExit = settings.eastExit;
+        copiedSettings.southExit = settings.southExit;
+        copiedSettings.westExit = settings.westExit;
+
+        return copiedSettings;
+    }
+}

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/RoomGeneratorSettingsDialog.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/menu/generator/RoomGeneratorSettingsDialog.java
@@ -1,0 +1,95 @@
+package com.interrupt.dungeoneer.editor.ui.menu.generator;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.utils.Align;
+import com.interrupt.dungeoneer.editor.ui.EditorUi;
+
+public class RoomGeneratorSettingsDialog extends Dialog {
+    private RoomGeneratorSettings settings;
+
+    public RoomGeneratorSettingsDialog(Skin skin, RoomGeneratorSettings settings) {
+        super("Room Generator Settings", skin);
+        this.settings = RoomGeneratorSettings.copy(settings);
+
+        getContentTable().pad(8);
+
+        makeSectionHeader("Exits");
+        makeBooleanInputField("Exit North", settings.northExit, new ApplyChangesHandler<Boolean>() {
+            @Override
+            public void apply(Boolean value, RoomGeneratorSettings settings) {
+                settings.northExit = value;
+            }
+        });
+        makeBooleanInputField("Exit East", settings.eastExit, new ApplyChangesHandler<Boolean>() {
+            @Override
+            public void apply(Boolean value, RoomGeneratorSettings settings) {
+                settings.eastExit = value;
+            }
+        });
+        makeBooleanInputField("Exit South", settings.southExit, new ApplyChangesHandler<Boolean>() {
+            @Override
+            public void apply(Boolean value, RoomGeneratorSettings settings) {
+                settings.southExit = value;
+            }
+        });
+        makeBooleanInputField("Exit West", settings.westExit, new ApplyChangesHandler<Boolean>() {
+            @Override
+            public void apply(Boolean value, RoomGeneratorSettings settings) {
+                settings.westExit = value;
+            }
+        });
+
+        getContentTable().pack();
+
+        button("Save", true);
+        button("Cancel", false);
+    }
+
+    private void makeSectionHeader(String label) {
+        getContentTable().add(label).align(Align.left).padLeft(-8f);
+        getContentTable().row();
+    }
+
+    private Label makeLabel(String name) {
+        Label label = new Label(name, EditorUi.smallSkin);
+        label.setColor(1f, 1f, 1f, 0.75f);
+
+        return label;
+    }
+
+    private SelectBox<Boolean> makeSelectBox(boolean value, ApplyChangesHandler<Boolean> handler) {
+        Boolean[] values = new Boolean[2];
+        values[0] = true;
+        values[1] = false;
+
+        SelectBox<Boolean> selectBox = new SelectBox<>(EditorUi.smallSkin);
+        selectBox.setItems(values);
+        selectBox.setSelectedIndex(value ? 0 : 1);
+        selectBox.addListener(new ChangeListener() {
+            public void changed(ChangeEvent changeEvent, Actor actor) {
+                handler.apply(selectBox.getSelected(), settings);
+            }
+        });
+
+        return selectBox;
+    }
+
+    private void makeBooleanInputField(String label, Boolean value, ApplyChangesHandler<Boolean> handler) {
+        getContentTable().add(makeLabel(label)).align(Align.left);
+        getContentTable().add(makeSelectBox(value, handler)).align(Align.left).fill();
+        getContentTable().row();
+    }
+
+    private interface ApplyChangesHandler<T> {
+        public void apply(T value, RoomGeneratorSettings settings);
+    }
+
+    public RoomGeneratorSettings getSettings() {
+        return settings;
+    }
+}


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/13063023/102716203-967cd800-42da-11eb-99f7-ce24a3a5e6d8.png)

## Summary
Adding possibility to modify which exits should be generated for a given room in the editor (for testing purposes only). I'm not sure, though, if there are any generated rooms in-game that have different exits.

`Level` -> `Generate Room` -> `Settings`