### PR TITLE
[Editor|Bug] Properties Panel Can Expand Without Bounds

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
@@ -424,8 +424,7 @@ public class EditorUi {
 
             if(resetScroll) entityPropertiesPane.setScrollY(0f);
 
-            propertiesSize.set(propertiesMenu.getWidth(), propertiesMenu.getHeight());
-            resize(stage.getWidth(), stage.getHeight());
+            resize();
 
             sidebarTable.setVisible(true);
         }
@@ -433,6 +432,10 @@ public class EditorUi {
             sidebarTable.setVisible(false);
             entityPropertiesPane.setScrollY(0f);
         }
+    }
+
+    public void resize() {
+        resize(stage.getWidth(), stage.getHeight());
     }
 
     public void resize(float width, float height) {
@@ -444,6 +447,9 @@ public class EditorUi {
         mainTable.pack();
 
         if(entityPropertiesPane != null && propertiesMenu != null) {
+            propertiesSize.set(Math.min(propertiesMenu.getWidth(), stage.getWidth() * 0.25f),
+                    propertiesMenu.getHeight());
+
             boolean fillsStage = propertiesSize.y > stage.getHeight() - menuBar.getHeight();
 
             entityPropertiesPane.setSize(propertiesSize.x + (fillsStage ? 60f : 30f), propertiesSize.y);

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/PropertiesMenu.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/PropertiesMenu.java
@@ -577,6 +577,8 @@ public class PropertiesMenu extends Table {
                 for (Entity entity : selectedEntities) {
                     currentField.set(entity, Integer.parseInt(val));
                 }
+
+                updateSize();
             }
         }
         catch(Exception ex) {
@@ -590,6 +592,8 @@ public class PropertiesMenu extends Table {
                 for (Entity entity : selectedEntities) {
                     currentField.set(entity, new Material(val.texAtlas, val.tex));
                 }
+
+                updateSize();
             }
         }
         catch(Exception ex) {
@@ -712,10 +716,17 @@ public class PropertiesMenu extends Table {
                     ((ProjectedDecal) entity).refresh();
                 }
             }
+
+            updateSize();
         }
         catch(Exception ex) {
             Gdx.app.error("DelvEdit", ex.getMessage());
         }
+    }
+
+    private void updateSize() {
+        pack();
+        Editor.app.ui.resize();
     }
 
     static public class DecimalsFilter implements TextField.TextFieldFilter {


### PR DESCRIPTION
## Summary
Fixes #199.

Fixes the entity properties panel resizing behavior.
- Maximum width of panel restricted to 25% of screen width
- Width adjusts dynamically when altering values in panel (growing/shrinking)
- Same width when closing/opening panel
- Width changes properly when resizing editor window