### PR TITLE
Fixes issue with keybinds not working after loading the game

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Options.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Options.java
@@ -98,7 +98,7 @@ public class Options {
         }
     }
 
-    public static void SetInputOptions(GamepadDefinition defaultGamepad) {
+    public static void SetKeyboardBindings() {
         Actions.keyBindings.put(Action.USE, Options.instance.key_use);
         Actions.keyBindings.put(Action.ATTACK, Options.instance.key_attack);
         Actions.keyBindings.put(Action.FORWARD, Options.instance.key_forward);
@@ -114,7 +114,9 @@ public class Options {
         Actions.keyBindings.put(Action.TURN_LEFT, Options.instance.key_turn_left);
         Actions.keyBindings.put(Action.TURN_RIGHT, Options.instance.key_turn_right);
         Actions.keyBindings.put(Action.JUMP, Options.instance.key_jump);
+    }
 
+    public static void SetGamepadBindings(GamepadDefinition defaultGamepad) {
         SetGamepadAction(Action.USE, Options.instance.gamepad_use, defaultGamepad);
         SetGamepadAction(Action.ATTACK, Options.instance.gamepad_attack, defaultGamepad);
         SetGamepadAction(Action.FORWARD, Options.instance.gamepad_forward, defaultGamepad);
@@ -171,6 +173,8 @@ public class Options {
             JsonUtil.toJson(o, file);
             return o;
         });
+
+        SetKeyboardBindings();
     }
 
     /** Save options to file. */

--- a/Dungeoneer/src/com/interrupt/dungeoneer/input/GamepadManager.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/input/GamepadManager.java
@@ -302,23 +302,30 @@ public class GamepadManager implements ControllerListener {
     	Controller first = Controllers.getControllers().first();
     	if(first != null) mapController(first);
     }
-    
-    public void mapController(Controller controller) {
-    	String controllerName = controller.getName().toLowerCase();
-    	if (controllerName.contains("microsoft corporatio controller"))
-    		controllerMapping.put(controller, new GamepadDefinition(new Xbox360OSXPad()));
-    	else if (controllerName.contains("microsoft") || controllerName.contains("xbox") || controllerName.contains("360"))
-			controllerMapping.put(controller, new GamepadDefinition(new Xbox360Pad()));
-		else if (controllerName.contains("sony"))
-			controllerMapping.put(controller, new GamepadDefinition(new SonyPad()));
-		else if(controller.getName().equals(Ouya.ID))
-			controllerMapping.put(controller, new GamepadDefinition(new Ouya()));
-		else if (controllerName.contains("moga"))
-			controllerMapping.put(controller, new GamepadDefinition(new MogaProPad()));
-		else
-			controllerMapping.put(controller, new GamepadDefinition(new Xbox360Pad()));
 
-		Options.SetInputOptions(controllerMapping.get(controller));
+    public void mapController(Controller controller) {
+        String controllerName = controller.getName().toLowerCase();
+
+        if (controllerName.contains("microsoft corporatio controller")) {
+            controllerMapping.put(controller, new GamepadDefinition(new Xbox360OSXPad()));
+        }
+        else if (controllerName.contains("microsoft") || controllerName.contains("xbox") || controllerName.contains("360")) {
+            controllerMapping.put(controller, new GamepadDefinition(new Xbox360Pad()));
+        }
+        else if (controllerName.contains("sony")) {
+            controllerMapping.put(controller, new GamepadDefinition(new SonyPad()));
+        }
+        else if (controller.getName().equals(Ouya.ID)) {
+            controllerMapping.put(controller, new GamepadDefinition(new Ouya()));
+        }
+        else if (controllerName.contains("moga")) {
+            controllerMapping.put(controller, new GamepadDefinition(new MogaProPad()));
+        }
+        else {
+            controllerMapping.put(controller, new GamepadDefinition(new Xbox360Pad()));
+        }
+
+        Options.SetGamepadBindings(controllerMapping.get(controller));
     }
     
     public Vector2 applyDeadzone(Vector2 rawInput) {


### PR DESCRIPTION
## Summary
Fixes issue with custom keybinds not working after relaunching the game. The issue was keybinds are set by the GamepadManager called in `Game.init()` which is called before `Options.loadOptions()` in `SplashScreen.java`. This results in using a temp instance of Options which are all the default keybinds.

## Fix
I decoupled setting gamepad bindings and key bindings. We set the keybindings whenever we load the options file and load the gamepad bindings once the GamepadManager has been initialized.

Fixes #201 