### PR TITLE
[Build] Dependabot Support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly


### PR DESCRIPTION
In case you don't know what dependabot is, it is a tool that watches for dependency updates and automatically creates PRs for that.

Down below is an output of me running a dry run of the delverengine repository. It seems to work. It is configured as a GitHub action and only works on `master`.

```
felix@DESKTOP-7VEHONE:/mnt/d/Downloads/dependabot-core-main/dependabot-core-main$ bin/dry-run.rb gradle interrupt/delverengine
Warning: the running version of Bundler (2.1.2) is older than the version that created the lockfile (2.1.4). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.1.4`.
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.2-compliant syntax, but you are running 2.7.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/interrupt/delverengine/
=> parsing dependency files
=> updating 7 dependencies: com.badlogicgames.gdx:gdx-backend-lwjgl, com.badlogicgames.gdx:gdx-controllers-desktop, org.reflections:reflections, com.badlogicgames.gdx:gdx, com.badlogicgames.gdx:gdx-controllers, com.esotericsoftware.kryo:kryo, com.bladecoder.ink:blade-ink

=== com.badlogicgames.gdx:gdx-backend-lwjgl (1.9.9)
 => checking for updates 1/7
 => latest available version is 1.9.14
 => latest allowed version is 1.9.9
 => requirements to unlock: update_not_possible
 => requirements update strategy:
    (no update possible 🙅‍♀️)

=== com.badlogicgames.gdx:gdx-controllers-desktop (1.9.9)
 => checking for updates 2/7
 => latest available version is 1.9.13
 => latest allowed version is 1.9.9
 => requirements to unlock: all
 => requirements update strategy:
 => updating com.badlogicgames.gdx:gdx-backend-lwjgl, com.badlogicgames.gdx:gdx-controllers-desktop, com.badlogicgames.gdx:gdx, com.badlogicgames.gdx:gdx-controllers

    ± build.gradle
    ~~~
    16c16
    <         gdxVersion = '1.9.9'
    ---
    >         gdxVersion = '1.9.13'
    ~~~

=== org.reflections:reflections (0.9.12)
 => checking for updates 3/7
 => latest available version is 0.9.12
 => latest allowed version is 0.9.12
    (no update needed as it's already up-to-date)

=== com.badlogicgames.gdx:gdx (1.9.9)
 => checking for updates 4/7
 => latest available version is 1.9.14
 => latest allowed version is 1.9.9
 => requirements to unlock: update_not_possible
 => requirements update strategy:
    (no update possible 🙅‍♀️)

=== com.badlogicgames.gdx:gdx-controllers (1.9.9)
 => checking for updates 5/7
 => latest available version is 1.9.13
 => latest allowed version is 1.9.9
 => requirements to unlock: all
 => requirements update strategy:
 => updating com.badlogicgames.gdx:gdx-backend-lwjgl, com.badlogicgames.gdx:gdx-controllers-desktop, com.badlogicgames.gdx:gdx, com.badlogicgames.gdx:gdx-controllers

    ± build.gradle
    ~~~
    16c16
    <         gdxVersion = '1.9.9'
    ---
    >         gdxVersion = '1.9.13'
    ~~~

=== com.esotericsoftware.kryo:kryo (2.24.0)
 => checking for updates 6/7
 => latest available version is 2.24.0
 => latest allowed version is 2.24.0
    (no update needed as it's already up-to-date)

=== com.bladecoder.ink:blade-ink (0.7.3)
 => checking for updates 7/7
 => latest available version is 0.7.4
 => latest allowed version is 0.7.4
 => requirements to unlock: own
 => requirements update strategy:
 => updating com.bladecoder.ink:blade-ink from 0.7.3 to 0.7.4

    ± build.gradle
    ~~~
    20c20
    <         inkVersion = '0.7.3'
    ---
    >         inkVersion = '0.7.4'
    ~~~
felix@DESKTOP-7VEHONE:/mnt/d/Downloads/dependabot-core-main/dependabot-core-main$ 
```