### PR TITLE
Some levels crash the editor

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/file/EditorFile.java
@@ -349,6 +349,7 @@ public class EditorFile {
     /** Loads a `.dat` level file. */
     private Level loadDatFile(FileHandle file) {
         Level level = JsonUtil.fromJson(Level.class, file);
+        level.postLoad();
         level.init(Level.Source.EDITOR);
 
         return level;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/serializers/KryoSerializer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/serializers/KryoSerializer.java
@@ -1,37 +1,8 @@
 package com.interrupt.dungeoneer.serializers;
 
-import java.io.*;
-import java.util.HashMap;
-
-import com.interrupt.dungeoneer.serializers.v1.LevelSerializer;
-import org.objenesis.strategy.SerializingInstantiatorStrategy;
-import org.objenesis.strategy.StdInstantiatorStrategy;
-
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.math.Vector3;
-import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.Array.ArrayIterator;
-import com.badlogic.gdx.utils.IntArray;
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.FastInput;
-import com.esotericsoftware.kryo.io.FastOutput;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
-import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer;
-import com.interrupt.dungeoneer.entities.Entity;
-import com.interrupt.dungeoneer.entities.Model;
-import com.interrupt.dungeoneer.entities.Monster;
-import com.interrupt.dungeoneer.entities.Particle;
-import com.interrupt.dungeoneer.entities.Prefab;
-import com.interrupt.dungeoneer.entities.Sprite;
 import com.interrupt.dungeoneer.game.Level;
-import com.interrupt.dungeoneer.gfx.drawables.DrawableMesh;
-import com.interrupt.dungeoneer.gfx.drawables.DrawableSprite;
-import com.interrupt.dungeoneer.tiles.Tile;
+import com.interrupt.dungeoneer.serializers.v1.LevelSerializer;
 
 public class KryoSerializer {
 	public static synchronized Level loadLevel(FileHandle file) {
@@ -42,7 +13,7 @@ public class KryoSerializer {
             return LevelSerializer.loadLevel(file);
         }
 	}
-	
+
 	public static synchronized Level loadLevel(byte[] bytes) {
         try {
             return com.interrupt.dungeoneer.serializers.v2.LevelSerializer.loadLevel(bytes);
@@ -60,11 +31,11 @@ public class KryoSerializer {
 	        return null;
         }
     }
-	
+
 	public static synchronized void saveLevel(FileHandle file, Level level) {
         com.interrupt.dungeoneer.serializers.v2.LevelSerializer.saveLevel(file, level);
 	}
-	
+
 	public static synchronized Object copyObject(Object object) {
 		return com.interrupt.dungeoneer.serializers.v2.LevelSerializer.copyObject(object);
 	}

--- a/Dungeoneer/src/com/interrupt/dungeoneer/serializers/v1/LevelSerializer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/serializers/v1/LevelSerializer.java
@@ -1,5 +1,12 @@
 package com.interrupt.dungeoneer.serializers.v1;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.util.HashMap;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
@@ -14,15 +21,23 @@ import com.esotericsoftware.kryo.io.FastOutput;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer;
-import com.interrupt.dungeoneer.entities.*;
+import com.interrupt.dungeoneer.entities.Entity;
+import com.interrupt.dungeoneer.entities.Model;
+import com.interrupt.dungeoneer.entities.Monster;
+import com.interrupt.dungeoneer.entities.Particle;
+import com.interrupt.dungeoneer.entities.Prefab;
+import com.interrupt.dungeoneer.entities.Sprite;
 import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.gfx.drawables.DrawableMesh;
 import com.interrupt.dungeoneer.gfx.drawables.DrawableSprite;
-import com.interrupt.dungeoneer.serializers.*;
+import com.interrupt.dungeoneer.serializers.ArraySerializer;
+import com.interrupt.dungeoneer.serializers.ColorSerializer;
+import com.interrupt.dungeoneer.serializers.HashMapSerializer;
+import com.interrupt.dungeoneer.serializers.IntArraySerializer;
+import com.interrupt.dungeoneer.serializers.LibGdxArrayIteratorSerializer;
+import com.interrupt.dungeoneer.serializers.PrefabSerializer;
+import com.interrupt.dungeoneer.serializers.TileSerializer;
 import com.interrupt.dungeoneer.tiles.Tile;
-
-import java.io.*;
-import java.util.HashMap;
 
 public class LevelSerializer {
 	private static Kryo kryo = new Kryo();

--- a/Dungeoneer/src/com/interrupt/dungeoneer/serializers/v1/LevelSerializer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/serializers/v1/LevelSerializer.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
-import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Array.ArrayIterator;
 import com.badlogic.gdx.utils.IntArray;
@@ -27,10 +26,10 @@ import java.util.HashMap;
 
 public class LevelSerializer {
 	private static Kryo kryo = new Kryo();
-	
+
 	static {
 		kryo.setDefaultSerializer(CompatibleFieldSerializer.class);
-		
+
 		// register some classes
 		kryo.register(Color.class);
 		kryo.register(Vector3.class);
@@ -44,7 +43,7 @@ public class LevelSerializer {
 		kryo.register(DrawableSprite.class);
 		kryo.register(DrawableMesh.class);
 		kryo.register(Array.class);
-		
+
 		// register some serializers
 		kryo.register(Prefab.class, new PrefabSerializer());
 		kryo.register(ArrayIterator.class, new LibGdxArrayIteratorSerializer());
@@ -54,39 +53,42 @@ public class LevelSerializer {
 		kryo.register(IntArray.class, new IntArraySerializer());
 		kryo.register(HashMap.class, new HashMapSerializer());
 	}
-	
+
 	public static Level loadLevel(FileHandle file) {
 		Input input = new Input(file.read());
 		Level level = kryo.readObject(input, Level.class);
 		input.close();
+        level.postLoad();
 		return level;
 	}
-	
+
 	public static Level loadLevel(File file) {
 		try {
 			Input input = new Input(new FileInputStream(file));
 			Level level = kryo.readObject(input, Level.class);
 			input.close();
+            level.postLoad();
 			return level;
 		}
 		catch (Exception ex) {
 			return null;
 		}
 	}
-	
+
 	public static Level loadLevel(byte[] bytes) {
 		Input input = new Input(bytes);
 		Level level = kryo.readObject(input, Level.class);
 		input.close();
+        level.postLoad();
 		return level;
 	}
-	
+
 	public static void saveLevel(FileHandle file, Level level) {
 		Output output = new Output(file.write(false));
 		kryo.writeObject(output, level);
 		output.close();
 	}
-	
+
 	public static void saveLevel(File file, Level level) {
 		try {
 			Output output;
@@ -97,7 +99,7 @@ public class LevelSerializer {
 			// oops!
 		}
 	}
-	
+
 	public static Object copyObject(Object object) {
 		if(object == null) return null;
 		try {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/serializers/v2/LevelSerializer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/serializers/v2/LevelSerializer.java
@@ -1,11 +1,17 @@
 package com.interrupt.dungeoneer.serializers.v2;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.util.HashMap;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
-import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Array.ArrayIterator;
 import com.badlogic.gdx.utils.IntArray;
@@ -15,17 +21,23 @@ import com.esotericsoftware.kryo.io.FastOutput;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer;
-import com.interrupt.dungeoneer.entities.*;
+import com.interrupt.dungeoneer.entities.Entity;
+import com.interrupt.dungeoneer.entities.Model;
+import com.interrupt.dungeoneer.entities.Monster;
+import com.interrupt.dungeoneer.entities.Particle;
+import com.interrupt.dungeoneer.entities.Prefab;
+import com.interrupt.dungeoneer.entities.Sprite;
 import com.interrupt.dungeoneer.game.Level;
 import com.interrupt.dungeoneer.game.OverworldLevel;
 import com.interrupt.dungeoneer.gfx.drawables.DrawableMesh;
 import com.interrupt.dungeoneer.gfx.drawables.DrawableSprite;
-import com.interrupt.dungeoneer.serializers.*;
+import com.interrupt.dungeoneer.serializers.ArraySerializer;
+import com.interrupt.dungeoneer.serializers.ColorSerializer;
+import com.interrupt.dungeoneer.serializers.HashMapSerializer;
+import com.interrupt.dungeoneer.serializers.IntArraySerializer;
+import com.interrupt.dungeoneer.serializers.LibGdxArrayIteratorSerializer;
+import com.interrupt.dungeoneer.serializers.PrefabSerializer;
 import com.interrupt.dungeoneer.tiles.Tile;
-import com.interrupt.dungeoneer.tiles.TileMaterials;
-
-import java.io.*;
-import java.util.HashMap;
 
 public class LevelSerializer {
 	private static Kryo kryo = new Kryo();
@@ -56,7 +68,7 @@ public class LevelSerializer {
 		kryo.register(IntArray.class, new IntArraySerializer());
 		kryo.register(HashMap.class, new HashMapSerializer());
 	}
-	
+
 	public static Level loadLevel(FileHandle file) {
 		Input input = new Input(file.read());
 		Level level = kryo.readObject(input, Level.class);
@@ -64,7 +76,7 @@ public class LevelSerializer {
 		level.postLoad();
 		return level;
 	}
-	
+
 	public static Level loadLevel(File file) {
 		try {
 			Input input = new Input(new FileInputStream(file));
@@ -77,7 +89,7 @@ public class LevelSerializer {
 			return null;
 		}
 	}
-	
+
 	public static Level loadLevel(byte[] bytes) {
 		Input input = new Input(bytes);
 		Level level = kryo.readObject(input, Level.class);
@@ -93,13 +105,13 @@ public class LevelSerializer {
 		level.postLoad();
 		return level;
 	}
-	
+
 	public static void saveLevel(FileHandle file, Level level) {
 		Output output = new Output(file.write(false));
 		kryo.writeObject(output, level);
 		output.close();
 	}
-	
+
 	public static void saveLevel(File file, Level level) {
 		try {
 			Output output;
@@ -110,7 +122,7 @@ public class LevelSerializer {
 			// oops!
 		}
 	}
-	
+
 	public static Object copyObject(Object object) {
 		if(object == null) return null;
 		try {


### PR DESCRIPTION
## Summary

Fixes #207 .

Fixes a crash related to loading `.dat` or v1 `.bin` level files when entering and exiting play mode. The `tileMaterials` array was not initialized properly in these cases.