### PR TITLE
Make Player Hand Lag Optional

### DIFF
--- a/Dungeoneer/assets/data/strings.dat
+++ b/Dungeoneer/assets/data/strings.dat
@@ -135,6 +135,11 @@
         "localizedName": "UI Size ",
         "comment": "Label for UI size slider."
     },
+    "screens.OptionsScreen.handLagLabel": {
+        "class": "com.interrupt.dungeoneer.game.LocalizedString",
+        "localizedName": "Hand Lag ",
+        "comment": "Label for hand lag slider."
+    },
     "screens.OptionsScreen.showHudLabel": {
         "class": "com.interrupt.dungeoneer.game.LocalizedString",
         "localizedName": "Show Hud ",

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
@@ -76,6 +76,9 @@ public class Player extends Actor {
 	/** Hand lag strength. */
 	public float handLagStrength = 0.6f;
 
+    /** Offhand lag strength. */
+	public float offhandLagStrength = 0.8f;
+
 	public boolean hasAttacked;
 
 	private float attackSpeed = 1;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
@@ -79,6 +79,12 @@ public class Player extends Actor {
     /** Offhand lag strength. */
 	public float offhandLagStrength = 0.8f;
 
+	/** Hand offset */
+	public Vector3 handOffset = new Vector3(-0.12f, -0.07f, 0.28f);
+
+	/** Offhand offset */
+	public Vector3 offhandOffset = new Vector3(0.12f, -0.14f, 0.24f);
+
 	public boolean hasAttacked;
 
 	private float attackSpeed = 1;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Player.java
@@ -73,6 +73,9 @@ public class Player extends Actor {
 	/** Head bob height. */
 	public float headBobHeight = 0.3f;
 
+	/** Hand lag strength. */
+	public float handLagStrength = 0.6f;
+
 	public boolean hasAttacked;
 
 	private float attackSpeed = 1;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Options.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Options.java
@@ -29,6 +29,7 @@ public class Options {
     public boolean useMouseScroller = true;
     public boolean hideUI = false;
     public boolean headBobEnabled = true;
+    public boolean handLagEnabled = true;
     public boolean shadowsEnabled = true;
     public boolean fxaaEnabled = false;
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2169,7 +2169,7 @@ public class GlRenderer {
 
 		// hand bob
 		cameraBob.set(game.player.xa, game.player.ya);
-		transform.y -= game.player.headbob * 0.35f;
+		transform.y += game.player.headbob * 0.35f;
 
 		TextureRegion held = heldItem.getHeldInventoryTextureRegion(texOffset);
 		TextureAtlas atlas = heldItem.getTextureAtlas();

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2179,12 +2179,12 @@ public class GlRenderer {
 			if(handMaxLerpTime > 1) handMaxLerpTime = 1f;
 		}
 
-        float handLagStrength = Game.instance.player.handLagStrength;
+        float offhandLagStrength = Game.instance.player.offhandLagStrength;
         if (!Options.instance.handLagEnabled) {
-            handLagStrength = 0;
+            offhandLagStrength = 0;
         }
-		handMaxDirectionOffhand.lerp(offhandLagRotation, handLagStrength);
-		forwardDirection.set(camera.direction).lerp(offhandLagRotation, handLagStrength);
+		handMaxDirectionOffhand.lerp(offhandLagRotation, offhandLagStrength);
+		forwardDirection.set(camera.direction).lerp(offhandLagRotation, offhandLagStrength);
 		downDirection.set(camera.up).nor();
 
 		offhandLagRotation.set(handMaxDirectionOffhand);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -36,6 +36,8 @@ import com.interrupt.dungeoneer.entities.triggers.TriggeredMessage;
 import com.interrupt.dungeoneer.entities.triggers.TriggeredMusic;
 import com.interrupt.dungeoneer.entities.triggers.TriggeredShop;
 import com.interrupt.dungeoneer.game.*;
+import com.interrupt.dungeoneer.gfx.animation.lerp3d.LerpFrame;
+import com.interrupt.dungeoneer.gfx.animation.lerp3d.LerpedAnimation;
 import com.interrupt.dungeoneer.gfx.decals.DDecal;
 import com.interrupt.dungeoneer.gfx.drawables.*;
 import com.interrupt.dungeoneer.gfx.shaders.ShaderInfo;
@@ -2152,6 +2154,18 @@ public class GlRenderer {
 		Vector3 rotation = heldRotation.set(0,0,0);
 		Vector3 transform = heldTransform.set(0,0,0);
 		int texOffset = 0;
+
+        if (heldItem instanceof Weapon) {
+            Weapon weapon = (Weapon)heldItem;
+            String animationName = weapon.attackAnimation;
+            LerpedAnimation animation = Game.animationManager.getAnimation(animationName);
+            if (animation != null) {
+                LerpFrame frame = animation.frames.get(0);
+                rotation.set(frame.rotation);
+                transform.set(-frame.transform.x, frame.transform.y, frame.transform.z);
+                texOffset = animation.curTexOffset;
+            }
+        }
 
 		// hand bob
 		cameraBob.set(game.player.xa, game.player.ya);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2017,8 +2017,12 @@ public class GlRenderer {
 			if(handMaxLerpTime > 1) handMaxLerpTime = 1f;
 		}
 
-		handMaxDirection.lerp(handLagRotation, 0.6f);
-		forwardDirection.set(camera.direction).lerp(handLagRotation, 0.6f);
+		float handLagStrength = Game.instance.player.handLagStrength;
+		if (!Options.instance.handLagEnabled) {
+		    handLagStrength = 0;
+        }
+		handMaxDirection.lerp(handLagRotation, handLagStrength);
+		forwardDirection.set(camera.direction).lerp(handLagRotation, handLagStrength);
 		downDirection.set(camera.up).nor();
 
 		handLagRotation.set(handMaxDirection);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -1972,6 +1972,7 @@ public class GlRenderer {
 		Vector3 rotation = heldRotation.set(0,0,0);
 		Vector3 transform = heldTransform.set(0,0,0);
 		int texOffset = 0;
+		Vector3 offset = game.player.handOffset;
 
 		if(game.player.handAnimation != null) {
 			rotation.set(game.player.handAnimation.curRotation);
@@ -2039,19 +2040,19 @@ public class GlRenderer {
 			heldItem.y = camera.position.z;
 
 			// translate forward
-			heldItem.x += handMaxDirection.x * (transform.z + 0.28f);
-			heldItem.z += handMaxDirection.y * (transform.z + 0.28f);
-			heldItem.y += handMaxDirection.z * (transform.z + 0.28f);
+			heldItem.x += handMaxDirection.x * (transform.z + offset.z);
+			heldItem.z += handMaxDirection.y * (transform.z + offset.z);
+			heldItem.y += handMaxDirection.z * (transform.z + offset.z);
 
 			// translate right
-			heldItem.x += rightDirection.x * (transform.x - 0.12f);
-			heldItem.z += rightDirection.y * (transform.x - 0.12f);
-			heldItem.y += rightDirection.z * (transform.x - 0.12f);
+			heldItem.x += rightDirection.x * (transform.x + offset.x);
+			heldItem.z += rightDirection.y * (transform.x + offset.x);
+			heldItem.y += rightDirection.z * (transform.x + offset.x);
 
 			// translate down
-			heldItem.x += downDirection.x * (transform.y - 0.07f);
-			heldItem.z += downDirection.y * (transform.y - 0.07f);
-			heldItem.y += downDirection.z * (transform.y - 0.07f);
+			heldItem.x += downDirection.x * (transform.y + offset.y);
+			heldItem.z += downDirection.y * (transform.y + offset.y);
+			heldItem.y += downDirection.z * (transform.y + offset.y);
 
 			((DrawableMesh)heldItem.drawable).dir.set(camera.direction);
 			((DrawableMesh)heldItem.drawable).rotX = rotation.x;
@@ -2099,19 +2100,19 @@ public class GlRenderer {
 			sd.rotateY(100f);
 
 		// translate forward
-		sd.translateX(handMaxDirection.x * (transform.z + 0.28f));
-		sd.translateY(handMaxDirection.y * (transform.z + 0.28f));
-		sd.translateZ(handMaxDirection.z * (transform.z + 0.28f));
+		sd.translateX(handMaxDirection.x * (transform.z + offset.z));
+		sd.translateY(handMaxDirection.y * (transform.z + offset.z));
+		sd.translateZ(handMaxDirection.z * (transform.z + offset.z));
 
 		// translate right
-		sd.translateX(rightDirection.x * (transform.x - 0.12f));
-		sd.translateY(rightDirection.y * (transform.x - 0.12f));
-		sd.translateZ(rightDirection.z * (transform.x - 0.12f));
+		sd.translateX(rightDirection.x * (transform.x + offset.x));
+		sd.translateY(rightDirection.y * (transform.x + offset.x));
+		sd.translateZ(rightDirection.z * (transform.x + offset.x));
 
 		// translate down
-		sd.translateX(downDirection.x * (transform.y - 0.07f));
-		sd.translateY(downDirection.y * (transform.y - 0.07f));
-		sd.translateZ(downDirection.z * (transform.y - 0.07f));
+		sd.translateX(downDirection.x * (transform.y + offset.y));
+		sd.translateY(downDirection.y * (transform.y + offset.y));
+		sd.translateZ(downDirection.z * (transform.y + offset.y));
 
 		sd.rotateX(rotation.x);
 		sd.rotateY(rotation.y);
@@ -2155,6 +2156,7 @@ public class GlRenderer {
 		Vector3 rotation = heldRotation.set(0,0,0);
 		Vector3 transform = heldTransform.set(0,0,0);
 		int texOffset = 0;
+        Vector3 offset = game.player.offhandOffset;
 
         if (heldItem instanceof Weapon) {
             Weapon weapon = (Weapon)heldItem;
@@ -2214,19 +2216,19 @@ public class GlRenderer {
 			heldItem.y = camera.position.z;
 
 			// translate forward
-			heldItem.x += handMaxDirectionOffhand.x * (transform.z + 0.24f);
-			heldItem.z += handMaxDirectionOffhand.y * (transform.z + 0.24f);
-			heldItem.y += handMaxDirectionOffhand.z * (transform.z + 0.24f);
+			heldItem.x += handMaxDirectionOffhand.x * (transform.z + offset.z);
+			heldItem.z += handMaxDirectionOffhand.y * (transform.z + offset.z);
+			heldItem.y += handMaxDirectionOffhand.z * (transform.z + offset.z);
 
 			// translate right
-			heldItem.x += rightDirection.x * (transform.x + 0.12f);
-			heldItem.z += rightDirection.y * (transform.x + 0.12f);
-			heldItem.y += rightDirection.z * (transform.x + 0.12f);
+			heldItem.x += rightDirection.x * (transform.x + offset.x);
+			heldItem.z += rightDirection.y * (transform.x + offset.x);
+			heldItem.y += rightDirection.z * (transform.x + offset.x);
 
 			// translate down
-			heldItem.x += downDirection.x * (transform.y - 0.14f);
-			heldItem.z += downDirection.y * (transform.y - 0.14f);
-			heldItem.y += downDirection.z * (transform.y - 0.14f);
+			heldItem.x += downDirection.x * (transform.y + offset.y);
+			heldItem.z += downDirection.y * (transform.y + offset.y);
+			heldItem.y += downDirection.z * (transform.y + offset.y);
 
 			((DrawableMesh)heldItem.drawable).dir.set(camera.direction);
 			((DrawableMesh)heldItem.drawable).rotX = rotation.x;
@@ -2274,19 +2276,19 @@ public class GlRenderer {
 			sd.rotateY(-150f);
 
 		// translate forward
-		sd.translateX(handMaxDirectionOffhand.x * (transform.z + 0.24f));
-		sd.translateY(handMaxDirectionOffhand.y * (transform.z + 0.24f));
-		sd.translateZ(handMaxDirectionOffhand.z * (transform.z + 0.24f));
+		sd.translateX(handMaxDirectionOffhand.x * (transform.z + offset.z));
+		sd.translateY(handMaxDirectionOffhand.y * (transform.z + offset.z));
+		sd.translateZ(handMaxDirectionOffhand.z * (transform.z + offset.z));
 
 		// translate right
-		sd.translateX(rightDirection.x * (transform.x + 0.12f));
-		sd.translateY(rightDirection.y * (transform.x + 0.12f));
-		sd.translateZ(rightDirection.z * (transform.x + 0.12f));
+		sd.translateX(rightDirection.x * (transform.x + offset.x));
+		sd.translateY(rightDirection.y * (transform.x + offset.x));
+		sd.translateZ(rightDirection.z * (transform.x + offset.x));
 
 		// translate down
-		sd.translateX(downDirection.x * (transform.y - 0.14f));
-		sd.translateY(downDirection.y * (transform.y - 0.14f));
-		sd.translateZ(downDirection.z * (transform.y - 0.14f));
+		sd.translateX(downDirection.x * (transform.y + offset.y));
+		sd.translateY(downDirection.y * (transform.y + offset.y));
+		sd.translateZ(downDirection.z * (transform.y + offset.y));
 
 		sd.rotateX(rotation.x);
 		sd.rotateY(rotation.y);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2017,9 +2017,9 @@ public class GlRenderer {
 			if(handMaxLerpTime > 1) handMaxLerpTime = 1f;
 		}
 
-		float handLagStrength = Game.instance.player.handLagStrength;
-		if (!Options.instance.handLagEnabled) {
-		    handLagStrength = 0;
+        float handLagStrength = Game.instance.player.handLagStrength;
+        if (!Options.instance.handLagEnabled) {
+            handLagStrength = 0;
         }
 		handMaxDirection.lerp(handLagRotation, handLagStrength);
 		forwardDirection.set(camera.direction).lerp(handLagRotation, handLagStrength);
@@ -2175,7 +2175,11 @@ public class GlRenderer {
 			handMaxDirectionOffhand.y = Interpolation.exp5.apply(0.25f, handMaxDirectionOffhand.y, offhandMaxLerpTime);
 		handMaxDirectionOffhand = handMaxDirectionOffhand.nor();
 
-		forwardDirection.set(camera.direction).lerp(offhandLagRotation, 0.8f);
+		float handLagStrength = Game.instance.player.handLagStrength;
+        if (!Options.instance.handLagEnabled) {
+            handLagStrength = 0;
+        }
+		forwardDirection.set(camera.direction).lerp(offhandLagRotation, handLagStrength);
 		downDirection.set(camera.up).nor();
 
 		offhandLagRotation.set(handMaxDirectionOffhand);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2132,6 +2132,8 @@ public class GlRenderer {
 		DecalBatch spriteBatch = invisible ? getDecalBatch("invisible", Entity.BlendMode.ALPHA) : getDecalBatch(heldItem.getShader(), heldItem.blendMode);
 		spriteBatch.add(sd);
 		spriteBatch.flush();
+
+		// Clear bound texture after rendering a DecalBatch
 		clearBoundTexture();
 
 		// update item position, for attachment stuff
@@ -2308,6 +2310,8 @@ public class GlRenderer {
 		DecalBatch spriteBatch = invisible ? getDecalBatch("invisible", Entity.BlendMode.ALPHA) : getDecalBatch(heldItem.getShader(), heldItem.blendMode);
 		spriteBatch.add(sd);
 		spriteBatch.flush();
+
+		// Clear bound texture after rendering a DecalBatch
 		clearBoundTexture();
 
 		// update item position, for attachment stuff

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2131,6 +2131,7 @@ public class GlRenderer {
 		DecalBatch spriteBatch = invisible ? getDecalBatch("invisible", Entity.BlendMode.ALPHA) : getDecalBatch(heldItem.getShader(), heldItem.blendMode);
 		spriteBatch.add(sd);
 		spriteBatch.flush();
+		clearBoundTexture();
 
 		// update item position, for attachment stuff
 		heldItem.setPosition(sd.getX() + game.player.xa, sd.getZ() + game.player.ya, sd.getY() + 0.35f + game.player.za);
@@ -2305,6 +2306,7 @@ public class GlRenderer {
 		DecalBatch spriteBatch = invisible ? getDecalBatch("invisible", Entity.BlendMode.ALPHA) : getDecalBatch(heldItem.getShader(), heldItem.blendMode);
 		spriteBatch.add(sd);
 		spriteBatch.flush();
+		clearBoundTexture();
 
 		// update item position, for attachment stuff
 		heldItem.setPosition(sd.getX() + game.player.xa, sd.getZ() + game.player.ya, sd.getY() + 0.35f + game.player.za);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -2005,7 +2005,7 @@ public class GlRenderer {
 			if(handMaxLerpTime < 0) handMaxLerpTime = 0;
 
 			// Give non-ranged items a max angle to look up
-			if(!(heldItem instanceof Bow || heldItem instanceof Wand || heldItem instanceof Gun)) {
+			if(!(heldItem instanceof Bow || heldItem instanceof Wand || heldItem instanceof Gun || !Options.instance.handLagEnabled || Game.instance.player.handLagStrength <= 0f)) {
 				if (handMaxDirection.y > 0.25f)
 					handMaxDirection.y = Interpolation.exp5.apply(0.25f, handMaxDirection.y, handMaxLerpTime);
 			}
@@ -2143,46 +2143,89 @@ public class GlRenderer {
 	}
 
 	protected void drawOffhandItem() {
-
-		if(game.player.isHoldingTwoHanded()) return;
+	    if(game.player.isHoldingTwoHanded()) return;
 		if(offhandLagRotation == null) offhandLagRotation = new Vector3(camera.direction);
 
 		Item heldItem = game.player.GetHeldOffhandItem();
 		if(heldItem == null) return;
 
-		Vector3 rotation = heldRotation;
-		Vector3 transform = heldTransform;
+		Vector3 rotation = heldRotation.set(0,0,0);
+		Vector3 transform = heldTransform.set(0,0,0);
+		int texOffset = 0;
 
 		// hand bob
 		cameraBob.set(game.player.xa, game.player.ya);
-		transform.y += game.player.headbob * 0.35f;
+		transform.y -= game.player.headbob * 0.35f;
 
-		TextureRegion held = heldItem.getHeldInventoryTextureRegion(0);
+		TextureRegion held = heldItem.getHeldInventoryTextureRegion(texOffset);
 		TextureAtlas atlas = heldItem.getTextureAtlas();
 
 		// Move the hands down as we look up
 		handMaxDirectionOffhand.set(camera.direction);
 		if(Game.instance.player.handAnimateTimer <= 0 && Game.instance.player.attackCharge <= 0) {
-			offhandMaxLerpTime -= 3f * Gdx.graphics.getDeltaTime();
-			if(offhandMaxLerpTime < 0) offhandMaxLerpTime = 0f;
+			handMaxLerpTime -= 2.5f * Gdx.graphics.getDeltaTime();
+			if(handMaxLerpTime < 0) handMaxLerpTime = 0;
+
+			// Give non-ranged items a max angle to look up
+			if(!(!Options.instance.handLagEnabled || Game.instance.player.handLagStrength <= 0f)) {
+				if (handMaxDirectionOffhand.y > 0.25f)
+					handMaxDirectionOffhand.y = Interpolation.exp5.apply(0.25f, handMaxDirection.y, handMaxLerpTime);
+			}
+
+			handMaxDirectionOffhand = handMaxDirectionOffhand.nor();
 		}
 		else {
-			offhandMaxLerpTime += 3f * Gdx.graphics.getDeltaTime();
-			if(offhandMaxLerpTime > 1) offhandMaxLerpTime = 1f;
+			handMaxLerpTime += 0.1f * Gdx.graphics.getDeltaTime();
+			if(handMaxLerpTime > 1) handMaxLerpTime = 1f;
 		}
 
-		if (handMaxDirectionOffhand.y > 0.25f)
-			handMaxDirectionOffhand.y = Interpolation.exp5.apply(0.25f, handMaxDirectionOffhand.y, offhandMaxLerpTime);
-		handMaxDirectionOffhand = handMaxDirectionOffhand.nor();
-
-		float handLagStrength = Game.instance.player.handLagStrength;
+        float handLagStrength = Game.instance.player.handLagStrength;
         if (!Options.instance.handLagEnabled) {
             handLagStrength = 0;
         }
+		handMaxDirectionOffhand.lerp(offhandLagRotation, handLagStrength);
 		forwardDirection.set(camera.direction).lerp(offhandLagRotation, handLagStrength);
 		downDirection.set(camera.up).nor();
 
 		offhandLagRotation.set(handMaxDirectionOffhand);
+
+		// Handle drawable meshes. First, make sure a model is loaded if this was just in the inventory
+		if(heldItem.shouldUseMesh(true))
+			heldItem.updateHeldDrawable();
+
+		if(heldItem.drawable instanceof DrawableMesh) {
+			heldItem.x = camera.position.x;
+			heldItem.z = camera.position.y + 0.5f - heldItem.yOffset; // Bump the held item up a bit, but negate the yOffset
+			heldItem.y = camera.position.z;
+
+			// translate forward
+			heldItem.x += handMaxDirectionOffhand.x * (transform.z + 0.24f);
+			heldItem.z += handMaxDirectionOffhand.y * (transform.z + 0.24f);
+			heldItem.y += handMaxDirectionOffhand.z * (transform.z + 0.24f);
+
+			// translate right
+			heldItem.x += rightDirection.x * (transform.x + 0.12f);
+			heldItem.z += rightDirection.y * (transform.x + 0.12f);
+			heldItem.y += rightDirection.z * (transform.x + 0.12f);
+
+			// translate down
+			heldItem.x += downDirection.x * (transform.y - 0.14f);
+			heldItem.z += downDirection.y * (transform.y - 0.14f);
+			heldItem.y += downDirection.z * (transform.y - 0.14f);
+
+			((DrawableMesh)heldItem.drawable).dir.set(camera.direction);
+			((DrawableMesh)heldItem.drawable).rotX = rotation.x;
+			((DrawableMesh)heldItem.drawable).rotY = rotation.y;
+			((DrawableMesh)heldItem.drawable).rotZ = rotation.z;
+			heldItem.drawable.update(heldItem);
+
+			Gdx.gl.glEnable(GL20.GL_CULL_FACE);
+			Gdx.gl.glDepthFunc(GL20.GL_LEQUAL);
+			renderMesh((DrawableMesh)heldItem.drawable, modelShaderInfo);
+			Gdx.gl.glDisable(GL20.GL_CULL_FACE);
+			Gdx.gl.glDepthFunc(GL20.GL_ALWAYS);
+			return;
+		}
 
 		DDecal sd = decalPool.obtain();
 		usedDecals.add(sd);
@@ -2193,7 +2236,7 @@ public class GlRenderer {
 		sd.setScale(heldItem.scale * atlas.scale * 0.5f);
 		sd.setTextureRegion(held);
 		sd.setTextureAtlas(atlas);
-		sd.setPosition(camera.position.x, camera.position.y - 0.07f, camera.position.z);
+		sd.setPosition(camera.position.x, camera.position.y, camera.position.z);
 		sd.setRotation(camera.direction, camera.up);
 		sd.setBlending(-1, -1);
 
@@ -2216,24 +2259,23 @@ public class GlRenderer {
 			sd.rotateY(-150f);
 
 		// translate forward
-		sd.translateX(forwardDirection.x * (0.24f));
-		sd.translateY(forwardDirection.y * (0.24f));
-		sd.translateZ(forwardDirection.z * (0.24f));
+		sd.translateX(handMaxDirectionOffhand.x * (transform.z + 0.24f));
+		sd.translateY(handMaxDirectionOffhand.y * (transform.z + 0.24f));
+		sd.translateZ(handMaxDirectionOffhand.z * (transform.z + 0.24f));
 
 		// translate right
-		sd.translateX(rightDirection.x * (0.12f + headRotation.z * 0.004f));
-		sd.translateY(rightDirection.y * (0.12f + headRotation.z * 0.004f));
-		sd.translateZ(rightDirection.z * (0.12f + headRotation.z * 0.004f));
+		sd.translateX(rightDirection.x * (transform.x + 0.12f));
+		sd.translateY(rightDirection.y * (transform.x + 0.12f));
+		sd.translateZ(rightDirection.z * (transform.x + 0.12f));
 
 		// translate down
-		float bob = game.player.headbob * 0.35f;
-		sd.translateX(downDirection.x * ((bob - 0.07f) - headRotation.z * 0.001f));
-		sd.translateY(downDirection.y * ((bob - 0.07f) - headRotation.z * 0.001f));
-		sd.translateZ(downDirection.z * ((bob - 0.07f) - headRotation.z * 0.001f));
+		sd.translateX(downDirection.x * (transform.y - 0.14f));
+		sd.translateY(downDirection.y * (transform.y - 0.14f));
+		sd.translateZ(downDirection.z * (transform.y - 0.14f));
 
-		sd.rotateX(0);
-		sd.rotateY(0);
-		sd.rotateZ(0);
+		sd.rotateX(rotation.x);
+		sd.rotateY(rotation.y);
+		sd.rotateZ(rotation.z);
 
 		if(heldItem.fullbrite) {
 			sd.setColor(heldItem.color);
@@ -2241,8 +2283,8 @@ public class GlRenderer {
 		else {
 			// set the color from the lightmap at the decal position
 			Color lightmapColor = GetLightmapAt(sd.getPosition().x, sd.getPosition().y, sd.getPosition().z);
-			heldItemOffhandColor.lerp(lightmapColor.r, lightmapColor.g, lightmapColor.b, 1f, 4.5f * Gdx.graphics.getDeltaTime());
-			sd.setColor(heldItemOffhandColor.r, heldItemOffhandColor.g, heldItemOffhandColor.b, 1.0f);
+			heldItemColor.lerp(lightmapColor.r, lightmapColor.g, lightmapColor.b, 1f, 4.5f * Gdx.graphics.getDeltaTime());
+			sd.setColor(heldItemColor.r, heldItemColor.g, heldItemColor.b, 1.0f);
 		}
 
 		// draw!

--- a/Dungeoneer/src/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
@@ -202,16 +202,18 @@ public class OptionsOverlay extends WindowOverlay {
         mainTable.row();
 
         // Hand lag
-        Label handLagLabel = new Label(StringManager.get("screens.OptionsScreen.handLagLabel"), skin.get(Label.LabelStyle.class));
-        mainTable.add(handLagLabel);
+        if (Game.instance.player.handLagStrength > 0f) {
+            Label handLagLabel = new Label(StringManager.get("screens.OptionsScreen.handLagLabel"), skin.get(Label.LabelStyle.class));
+            mainTable.add(handLagLabel);
 
-        handLag = new CheckBox(null, skin.get(CheckBox.CheckBoxStyle.class));
-        handLag.setChecked(Options.instance.handLagEnabled);
+            handLag = new CheckBox(null, skin.get(CheckBox.CheckBoxStyle.class));
+            handLag.setChecked(Options.instance.handLagEnabled);
 
-        addGamepadButtonOrder(handLag, handLagLabel);
+            addGamepadButtonOrder(handLag, handLagLabel);
 
-        mainTable.add(handLag);
-        mainTable.row();
+            mainTable.add(handLag);
+            mainTable.row();
+        }
 
         // Fullscreen Mode
         if(!(Gdx.app.getType() == Application.ApplicationType.Android || Gdx.app.getType() == Application.ApplicationType.iOS)) {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
@@ -4,15 +4,18 @@ import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Input;
+import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Align;
 import com.interrupt.dungeoneer.Audio;
+import com.interrupt.dungeoneer.entities.Player;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Options;
 import com.interrupt.dungeoneer.ui.UiSkin;
 import com.interrupt.managers.StringManager;
+import com.interrupt.utils.JsonUtil;
 
 public class OptionsOverlay extends WindowOverlay {
 
@@ -202,7 +205,16 @@ public class OptionsOverlay extends WindowOverlay {
         mainTable.row();
 
         // Hand lag
-        if (Game.instance.player.handLagStrength > 0f) {
+        Player playerData;
+        if (Game.instance != null && Game.instance.player != null) {
+            playerData = Game.instance.player;
+        }
+        else {
+            FileHandle file = Game.findInternalFileInMods("data/player.dat");
+            playerData = JsonUtil.fromJson(Player.class, file, Player::new);
+        }
+
+        if (playerData.handLagStrength > 0f) {
             Label handLagLabel = new Label(StringManager.get("screens.OptionsScreen.handLagLabel"), skin.get(Label.LabelStyle.class));
             mainTable.add(handLagLabel);
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
@@ -4,13 +4,11 @@ import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Input;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Align;
 import com.interrupt.dungeoneer.Audio;
-import com.interrupt.dungeoneer.game.Colors;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Options;
 import com.interrupt.dungeoneer.ui.UiSkin;
@@ -49,6 +47,7 @@ public class OptionsOverlay extends WindowOverlay {
 
     private CheckBox showUI;
     private CheckBox headBob;
+    private CheckBox handLag;
 
     public OptionsOverlay() {
         animateBackground = false;
@@ -202,6 +201,18 @@ public class OptionsOverlay extends WindowOverlay {
         mainTable.add(headBob);
         mainTable.row();
 
+        // Hand lag
+        Label handLagLabel = new Label(StringManager.get("screens.OptionsScreen.handLagLabel"), skin.get(Label.LabelStyle.class));
+        mainTable.add(handLagLabel);
+
+        handLag = new CheckBox(null, skin.get(CheckBox.CheckBoxStyle.class));
+        handLag.setChecked(Options.instance.handLagEnabled);
+
+        addGamepadButtonOrder(handLag, handLagLabel);
+
+        mainTable.add(handLag);
+        mainTable.row();
+
         // Fullscreen Mode
         if(!(Gdx.app.getType() == Application.ApplicationType.Android || Gdx.app.getType() == Application.ApplicationType.iOS)) {
             fullscreenMode = new CheckBox("", skin.get(CheckBox.CheckBoxStyle.class));
@@ -325,6 +336,7 @@ public class OptionsOverlay extends WindowOverlay {
         Options.instance.graphicsDetailLevel = (int)gfxQuality.getValue();
         Options.instance.hideUI = !showUI.isChecked();
         Options.instance.headBobEnabled = headBob.isChecked();
+        Options.instance.handLagEnabled = handLag.isChecked();
         if(fullscreenMode != null) Options.instance.fullScreen = fullscreenMode.isChecked();
         Options.saveOptions();
     }

--- a/jsonschema/current/dungeoneer/entities/Player.schema.json
+++ b/jsonschema/current/dungeoneer/entities/Player.schema.json
@@ -53,6 +53,12 @@
             "baseClass": "Player",
             "default": 0.3
         },
+        "handLagStrength": {
+            "type": "number",
+            "description": "Hand lag amount.",
+            "baseClass": "Player",
+            "default": 0.6
+        },
         "keys": {
             "type": "number",
             "description": "Player key count.",

--- a/jsonschema/current/dungeoneer/entities/Player.schema.json
+++ b/jsonschema/current/dungeoneer/entities/Player.schema.json
@@ -59,6 +59,12 @@
             "baseClass": "Player",
             "default": 0.6
         },
+        "offhandLagStrength": {
+            "type": "number",
+            "description": "Offhand lag amount.",
+            "baseClass": "Player",
+            "default": 0.8
+        },
         "keys": {
             "type": "number",
             "description": "Player key count.",

--- a/jsonschema/current/dungeoneer/entities/Player.schema.json
+++ b/jsonschema/current/dungeoneer/entities/Player.schema.json
@@ -65,6 +65,26 @@
             "baseClass": "Player",
             "default": 0.8
         },
+        "handOffset": {
+            "$ref": "../../gdx/Vector3.schema.json",
+            "description": "Hand offset.",
+            "baseClass": "Player",
+            "default": {
+                "x": -0.12,
+                "y": -0.07,
+                "z": 0.28
+            }
+        },
+        "offhandOffset": {
+            "$ref": "../../gdx/Vector3.schema.json",
+            "description": "Offhand offset.",
+            "baseClass": "Player",
+            "default": {
+                "x": 0.12,
+                "y": -0.14,
+                "z": 0.24
+            }
+        },
         "keys": {
             "type": "number",
             "description": "Player key count.",


### PR DESCRIPTION
![hand-lag-option-demo](https://user-images.githubusercontent.com/372642/114628147-45b73380-9c6b-11eb-889a-ddc9153ba71c.gif)

## Summary
Many players complain about mouse acceleration, but there is no mouse acceleration. I believe they are mistaking hand lag for mouse acceleration. This change allows players to turn off hand lag.

## Changes
- Added a hand lag toggle option
- Added a `handLagStrength` field to the Player class to make the effect tunable.
- If hand lag toggled off, weapons don't move down when player looks up.
- Made offhand have parity with primary hand. Namely support for drawable meshes.
- Made held item offsets configurable on Player object.