### PR TITLE
Read Data From Zip Files

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorArt.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorArt.java
@@ -14,20 +14,20 @@ import com.interrupt.dungeoneer.ui.UiSkin;
 import com.interrupt.utils.JsonUtil;
 
 public class EditorArt {
-	
+
 	private static boolean didInit = false;
-	
+
 	private static String[] atlasList = null;
-	
+
 	public static void initAtlases() {
-		FileHandle itemFile = Game.getInternal("data/spritesheets.dat");
+		FileHandle itemFile = Game.resolveFile("data/spritesheets.dat");
 		TextureAtlas[] atlases = JsonUtil.fromJson(TextureAtlas[].class, itemFile);
-		
+
 		atlasList = new String[atlases.length + 1];
 		int curAtlas = 0;
 
         atlasList[0] = "NONE";
-		
+
 		for(TextureAtlas atlas : atlases) {
 			TextureAtlas.cacheAtlas(atlas, atlas.name);
 			atlasList[1 + curAtlas++] = atlas.name;
@@ -35,20 +35,20 @@ public class EditorArt {
 
         didInit = true;
 	}
-	
+
 	public static TextureAtlas getAtlas(String name) {
 		if(!didInit) {
 			initAtlases();
 		}
-		
+
 		return TextureAtlas.getCachedRegion(name);
 	}
-	
+
 	public static String[] getAtlasList() {
 		if(!didInit) {
 			initAtlases();
 		}
-		
+
 		return atlasList;
 	}
 

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/AssetPicker.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/AssetPicker.java
@@ -312,7 +312,7 @@ public class AssetPicker extends Dialog {
 
             Gdx.app.log("DelvEdit", "Looking for files in: " + modFolderPath);
 
-            FileHandle gf = Game.getInternal(modFolderPath);
+            FileHandle gf = Game.resolveFile(modFolderPath);
             if(gf.exists()) {
                 for(FileHandle entry : Game.listDirectory(gf)) {
                     AssetListItem item = new AssetListItem(path + "/" + entry.name(), entry.name(), entry.extension().equals(""), path);

--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/EditorUi.java
@@ -56,14 +56,14 @@ public class EditorUi {
     Viewport viewport;
 
     public EditorUi() {
-        defaultSkin = new Skin(Game.getInternal("ui/editor/HoloSkin/Holo-dark-hdpi.json"),
-                new TextureAtlas(Game.getInternal("ui/editor/HoloSkin/Holo-dark-hdpi.atlas")));
+        defaultSkin = new Skin(Game.resolveFile("ui/editor/HoloSkin/Holo-dark-hdpi.json"),
+                new TextureAtlas(Game.resolveFile("ui/editor/HoloSkin/Holo-dark-hdpi.atlas")));
 
-        mediumSkin = new Skin(Game.getInternal("ui/editor/HoloSkin/Holo-dark-mdpi.json"),
-                new TextureAtlas(Game.getInternal("ui/editor/HoloSkin/Holo-dark-mdpi.atlas")));
+        mediumSkin = new Skin(Game.resolveFile("ui/editor/HoloSkin/Holo-dark-mdpi.json"),
+                new TextureAtlas(Game.resolveFile("ui/editor/HoloSkin/Holo-dark-mdpi.atlas")));
 
-        smallSkin = new Skin(Game.getInternal("ui/editor/HoloSkin/Holo-dark-ldpi.json"),
-                new TextureAtlas(Game.getInternal("ui/editor/HoloSkin/Holo-dark-ldpi.atlas")));
+        smallSkin = new Skin(Game.resolveFile("ui/editor/HoloSkin/Holo-dark-ldpi.json"),
+                new TextureAtlas(Game.resolveFile("ui/editor/HoloSkin/Holo-dark-ldpi.atlas")));
 
         viewport = new FillViewport(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
         stage = new Stage(viewport);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -46,7 +46,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -257,7 +257,7 @@ public class Game {
 	private static String[] getPackagedFiles() {
 		// find packaged files
 		Gdx.app.debug("Delver", "Looking in packaged_files");
-		FileHandle allAssets = getInternal("packaged_files.txt");
+		FileHandle allAssets = resolveFile("packaged_files.txt");
 		if(allAssets != null)  return allAssets.readString().split("\\r?\\n");
 		else return new String[] { };
 	}
@@ -292,7 +292,7 @@ public class Game {
                     String sub = s.substring(path.length());
                     if(!sub.contains("/")) {
                         Gdx.app.debug("Delver", "Found in packaged_files: " + i);
-                        FileHandle f = getInternal(s);
+                        FileHandle f = resolveFile(s);
                         if (f.exists() && !files.contains(f, false)) {
                             files.add(f);
                         }
@@ -316,7 +316,7 @@ public class Game {
 		for (int i = 0; i < packagedFiles.length; i++) {
 			String s = packagedFiles[i];
 			if (s.endsWith(filename)) {
-				FileHandle f = getInternal(s);
+				FileHandle f = resolveFile(s);
 				if (f.exists() && !files.contains(f, false)) {
 					files.add(f);
 				}
@@ -342,7 +342,7 @@ public class Game {
         for(String folder : Game.modManager.modsFound) {
             Gdx.app.debug("Delver", "Looking in " + folder);
 
-            FileHandle generatorFolder = getInternal(folder + "/generator");
+            FileHandle generatorFolder = resolveFile(folder + "/generator");
 
             Gdx.app.debug("Delver", "Looking for files in " + generatorFolder.path());
             for(FileHandle g : listDirectory(generatorFolder)) {
@@ -1394,6 +1394,7 @@ public class Game {
 		return interactMode;
 	}
 
+    /** Gets a file directly from the given path. */
     public static FileHandle getFile(String path) {
         if (OSUtils.isMac()) {
             // OSX needs this user.dir property to figure out where it is running from, and probably linux
@@ -1414,8 +1415,16 @@ public class Game {
         return new FileHandle(path);
     }
 
-    // Grabs from an external assets dir if available, or gets internal
-    static public FileHandle getInternal(String path) {
+    /** Gets a file according to resolution order. <br>
+     * Resolution Priority Order:
+     * <ol>
+     *   <li> assets directory
+     *   <li> assets.zip file
+     *   <li> zip file
+     *   <li> local file/JAR file
+     * </ol>
+     */
+    static public FileHandle resolveFile(String path) {
         Gdx.app.debug("Delver", "Looking for " + path);
 
         // Check for an assets directory. E.g. assets/font.png
@@ -1432,7 +1441,7 @@ public class Game {
         h = getZip(path);
         if (h.exists()) return h;
 
-        // Check inside JAR file
+        // Check inside JAR file/local file
         Gdx.app.debug("Delver", " Not found, looking internally");
         h = Gdx.files.internal(path);
 
@@ -1458,7 +1467,7 @@ public class Game {
             result = new ZipFileHandle(z, f.file(), zipEntryName);
         }
         catch (Exception ignored) {
-            Gdx.app.log("Delver", "Unable to open zip: " + zipFilePath);
+            Gdx.app.debug("Delver", "Unable to open zip: " + zipFilePath);
         }
 
         return result;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -1415,7 +1415,8 @@ public class Game {
         return new FileHandle(path);
     }
 
-    /** Gets a file according to resolution order. <br>
+    /**
+     * Gets a file according to resolution order. <br>
      * Resolution Priority Order:
      * <ol>
      *   <li> assets directory
@@ -1449,6 +1450,9 @@ public class Game {
 
         return h;
     }
+
+    @Deprecated
+    static public FileHandle getInternal(String path) { return resolveFile(path); }
 
     /** Returns a ZipFileHandle for an asset inside a zip file. */
     static private FileHandle getZip(String filename) {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -49,7 +49,6 @@ import java.util.Comparator;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.zip.ZipFile;
 
 public class Game {
 	/** Engine version */
@@ -1435,11 +1434,11 @@ public class Game {
 
         // Check for an assets.zip file. E.g. assets.zip/font.png
         Gdx.app.debug("Delver", " Not found, looking for zip files");
-        h = getZip("assets.zip/" + path);
+        h = ZipFileHandle.get("assets.zip/" + path);
         if (h.exists()) return h;
 
         // Check for a zip file. Eg. mods/example-mod.zip/font.png
-        h = getZip(path);
+        h = ZipFileHandle.get(path);
         if (h.exists()) return h;
 
         // Check inside JAR file/local file
@@ -1453,29 +1452,6 @@ public class Game {
 
     @Deprecated
     static public FileHandle getInternal(String path) { return resolveFile(path); }
-
-    /** Returns a ZipFileHandle for an asset inside a zip file. */
-    static private FileHandle getZip(String filename) {
-        FileHandle result = Gdx.files.internal(filename);
-
-        if (!filename.contains(".zip")) return result;
-
-        int i = filename.indexOf(".zip") + ".zip".length();
-        String zipFilePath = filename.substring(0, i);
-        String zipEntryName = filename.substring(i);
-        if (zipEntryName.startsWith("/")) zipEntryName = zipEntryName.substring(1);
-
-        try {
-            FileHandle f = Gdx.files.internal(zipFilePath);
-            ZipFile z = new ZipFile(f.file());
-            result = new ZipFileHandle(z, f.file(), zipEntryName);
-        }
-        catch (Exception ignored) {
-            Gdx.app.debug("Delver", "Unable to open zip: " + zipFilePath);
-        }
-
-        return result;
-    }
 
     static public FileHandle findInternalFileInMods(String filename) {
 		if(filename == null) return null;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -1118,26 +1118,6 @@ public class Game {
 		player.saveVersion = SAVE_VERSION;
 	}
 
-    public static FileHandle getFile(String file) {
-        if (OSUtils.isMac()) {
-            // OSX needs this user.dir property to figure out where it is running from, and probably linux
-            String userDir = System.getProperty("user.dir");
-            if (userDir != null) {
-                return new FileHandle(userDir + "/" + file);
-            }
-        }
-
-        if (OSUtils.isMobile() && Gdx.files != null) {
-            if (Gdx.files.isExternalStorageAvailable()) {
-                return Gdx.files.external("Delver/" + file);
-            }
-
-            return Gdx.files.local("Delver/" + file);
-        }
-
-        return new FileHandle(file);
-    }
-
 	public static Level GetLevel()
 	{
 		return instance.level;
@@ -1414,27 +1394,47 @@ public class Game {
 		return interactMode;
 	}
 
+    public static FileHandle getFile(String path) {
+        if (OSUtils.isMac()) {
+            // OSX needs this user.dir property to figure out where it is running from, and probably linux
+            String userDir = System.getProperty("user.dir");
+            if (userDir != null) {
+                return new FileHandle(userDir + "/" + path);
+            }
+        }
+
+        if (OSUtils.isMobile() && Gdx.files != null) {
+            if (Gdx.files.isExternalStorageAvailable()) {
+                return Gdx.files.external("Delver/" + path);
+            }
+
+            return Gdx.files.local("Delver/" + path);
+        }
+
+        return new FileHandle(path);
+    }
+
     // Grabs from an external assets dir if available, or gets internal
-    static public FileHandle getInternal(String filename) {
-        Gdx.app.debug("Delver", "Looking for " + filename);
+    static public FileHandle getInternal(String path) {
+        Gdx.app.debug("Delver", "Looking for " + path);
 
         // Check for an assets directory. E.g. assets/font.png
-        if (filename.startsWith("./")) filename = filename.substring(2);
-        FileHandle h = getFile("assets/" + filename);
+        if (path.startsWith("./")) path = path.substring(2);
+        FileHandle h = getFile("assets/" + path);
         if (h.exists()) return h;
 
         // Check for an assets.zip file. E.g. assets.zip/font.png
         Gdx.app.debug("Delver", " Not found, looking for zip files");
-        h = getZip("assets.zip/" + filename);
+        h = getZip("assets.zip/" + path);
         if (h.exists()) return h;
 
         // Check for a zip file. Eg. mods/example-mod.zip/font.png
-        h = getZip(filename);
+        h = getZip(path);
         if (h.exists()) return h;
 
         // Check inside JAR file
         Gdx.app.debug("Delver", " Not found, looking internally");
-        h = Gdx.files.internal(filename);
+        h = Gdx.files.internal(path);
 
         if (!h.exists()) Gdx.app.debug("Delver", "  Still not found!");
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -33,6 +33,7 @@ import com.interrupt.dungeoneer.screens.GameScreen;
 import com.interrupt.dungeoneer.serializers.KryoSerializer;
 import com.interrupt.dungeoneer.ui.*;
 import com.interrupt.dungeoneer.ui.Hud.DragAndDropResult;
+import com.interrupt.files.ZipFileHandle;
 import com.interrupt.managers.EntityManager;
 import com.interrupt.managers.ItemManager;
 import com.interrupt.managers.MonsterManager;
@@ -45,9 +46,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.zip.ZipFile;
 
 public class Game {
 	/** Engine version */
@@ -1424,6 +1427,25 @@ public class Game {
         Gdx.app.debug("Delver", " Not found, looking internally");
 
         h = Gdx.files.internal(filename);
+
+        if(!h.exists()) Gdx.app.debug("Delver", " Not found, looking for zip files");
+
+        if (filename.contains(".zip")) {
+            int i = filename.indexOf(".zip") + ".zip".length();
+
+            String zipFilePath = filename.substring(0, i);
+            String zipEntryName = filename.substring(i);
+            if (zipEntryName.startsWith("/")) zipEntryName = zipEntryName.substring(1);
+
+            try {
+                FileHandle f = Gdx.files.internal(zipFilePath);
+                ZipFile z = new ZipFile(f.file());
+                h = new ZipFileHandle(z, f.file(), zipEntryName);
+            }
+            catch (Exception ignored) {
+                Gdx.app.log("Delver", "Unable to open zip: " + zipFilePath);
+            }
+        }
 
         if(!h.exists()) Gdx.app.debug("Delver", "  Still not found!");
 

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/ModManager.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/ModManager.java
@@ -4,7 +4,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ArrayMap;
-import com.badlogic.gdx.utils.Json;
 import com.interrupt.api.steam.SteamApi;
 import com.interrupt.api.steam.workshop.WorkshopModData;
 import com.interrupt.dungeoneer.entities.Door;
@@ -91,7 +90,12 @@ public class ModManager {
 
         FileHandle fh = Game.getInternal("mods");
         for(FileHandle h : fh.list()) {
-            if(h.isDirectory()) allMods.add("mods/" + h.name());
+            if(h.isDirectory()) {
+                allMods.add("mods/" + h.name());
+            }
+            else if (h.extension().equals("zip")) {
+                allMods.add("mods/" + h.name());
+            }
         }
 
         // add any mods subscribed in Steam Workshop

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/ModManager.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/ModManager.java
@@ -88,7 +88,7 @@ public class ModManager {
         // add the default search paths
         allMods.add(".");
 
-        FileHandle fh = Game.getInternal("mods");
+        FileHandle fh = Game.resolveFile("mods");
         for(FileHandle h : fh.list()) {
             if(h.isDirectory()) {
                 allMods.add("mods/" + h.name());
@@ -118,7 +118,7 @@ public class ModManager {
     private void loadExcludesList() {
         for(String path : modsFound) {
             try {
-                FileHandle modFile = Game.getInternal(path + "/data/excludes.dat");
+                FileHandle modFile = Game.resolveFile(path + "/data/excludes.dat");
                 if (modFile.exists()) {
                     Array<String> excludes = JsonUtil.fromJson(Array.class, modFile);
                     if(excludes != null) {
@@ -138,7 +138,7 @@ public class ModManager {
             for (String path : modsFound) {
                 String filePath = path + "/data/" + filename;
                 try {
-                    FileHandle modFile = Game.getInternal(filePath);
+                    FileHandle modFile = Game.resolveFile(filePath);
                     if (modFile.exists() && !pathIsExcluded(filePath)) {
                         EntityManager thisModManager = JsonUtil.fromJson(EntityManager.class, modFile);
                         if (entityManager == null) {
@@ -161,7 +161,7 @@ public class ModManager {
             for (String path : modsFound) {
                 String filePath = path + "/data/" + filename;
                 try {
-                    FileHandle modFile = Game.getInternal(filePath);
+                    FileHandle modFile = Game.resolveFile(filePath);
                     if (modFile.exists() && !pathIsExcluded(filePath)) {
                         ItemManager thisModManager = JsonUtil.fromJson(ItemManager.class, modFile);
                         if (itemManager == null) {
@@ -184,7 +184,7 @@ public class ModManager {
             for (String path : modsFound) {
                 String filePath = path + "/data/" + filename;
                 try {
-                    FileHandle modFile = Game.getInternal(filePath);
+                    FileHandle modFile = Game.resolveFile(filePath);
                     if (modFile.exists() && !pathIsExcluded(filePath)) {
                         MonsterManager thisModManager = JsonUtil.fromJson(MonsterManager.class, modFile);
                         if (monsterManager == null) {
@@ -206,7 +206,7 @@ public class ModManager {
 
         for(String path : modsFound) {
             try {
-                FileHandle modFile = Game.getInternal(path + "/data/" + filename);
+                FileHandle modFile = Game.resolveFile(path + "/data/" + filename);
                 if(modFile.exists() && !pathIsExcluded(path + "/data/" + filename)) {
                     TextureAtlas[] atlases = JsonUtil.fromJson(TextureAtlas[].class, modFile);
 
@@ -234,7 +234,7 @@ public class ModManager {
 
         for(String path : modsFound) {
             try {
-                FileHandle modFile = Game.getInternal(path + "/data/tiles.dat");
+                FileHandle modFile = Game.resolveFile(path + "/data/tiles.dat");
                 if(modFile.exists() && !pathIsExcluded(path + "/data/tiles.dat")) {
                     TileManager tileManager = JsonUtil.fromJson(TileManager.class, modFile);
                     if(tileManager.tileData != null) combinedTileManager.tileData.putAll(tileManager.tileData);
@@ -256,7 +256,7 @@ public class ModManager {
 
         for(String path: modsFound) {
             try {
-                FileHandle modFile = Game.getInternal(path + "/data/shaders.dat");
+                FileHandle modFile = Game.resolveFile(path + "/data/shaders.dat");
                 if(modFile.exists() && !pathIsExcluded(path + "/data/shaders.dat")) {
                     ShaderData[] shaders = JsonUtil.fromJson(ShaderData[].class, modFile);
                     for(int i = 0; i < shaders.length; i++) {
@@ -279,7 +279,7 @@ public class ModManager {
 
         for(String path : modsFound) {
             try {
-                FileHandle modFile = Game.getInternal(path + "/data/animations.dat");
+                FileHandle modFile = Game.resolveFile(path + "/data/animations.dat");
                 if(modFile.exists() && !pathIsExcluded(path + "/data/animations.dat")) {
                     LerpedAnimationManager modManager = JsonUtil.fromJson(LerpedAnimationManager.class, modFile);
                     animationManager.animations.putAll(modManager.animations);
@@ -301,7 +301,7 @@ public class ModManager {
 
         for(String path : modsFound) {
             try {
-                FileHandle modFile = Game.getInternal(path + "/data/strings.dat");
+                FileHandle modFile = Game.resolveFile(path + "/data/strings.dat");
                 if(modFile.exists() && !pathIsExcluded(path + "/data/strings.dat")) {
                     HashMap<String, LocalizedString> localizedStrings = JsonUtil.fromJson(HashMap.class, modFile);
                     if (!localizedStrings.isEmpty()) {
@@ -323,7 +323,7 @@ public class ModManager {
 
         for(String path : modsFound) {
             try {
-                FileHandle modFile = Game.getInternal(path + "/data/game.dat");
+                FileHandle modFile = Game.resolveFile(path + "/data/game.dat");
                 if(modFile.exists() && !pathIsExcluded(path + "/data/game.dat")) {
                     GameData modData = JsonUtil.fromJson(GameData.class, modFile);
                     gameData.merge(modData);
@@ -341,7 +341,7 @@ public class ModManager {
     public GenTheme loadTheme(String filename) {
         GenTheme combinedTheme = new GenTheme();
         for (String path: modsFound) {
-            FileHandle modFile = Game.getInternal(path + "/" + filename);
+            FileHandle modFile = Game.resolveFile(path + "/" + filename);
             if (modFile.exists() && !pathIsExcluded(path + "/" + filename)) {
                 GenTheme theme = JsonUtil.fromJson(GenTheme.class, modFile);
 
@@ -441,7 +441,7 @@ public class ModManager {
         for(int i = 0; i < modsFound.size; i++) {
             String path = modsFound.get(i);
             if(!pathIsExcluded(path + "/" + filename)) {
-                FileHandle modFile = Game.getInternal(path + "/" + filename);
+                FileHandle modFile = Game.resolveFile(path + "/" + filename);
                 if (modFile.exists()) foundHandle = modFile;
             }
         }
@@ -486,7 +486,7 @@ public class ModManager {
         ArrayMap<FileHandle, FileHandle[]> filesByDirectory = new ArrayMap<FileHandle, FileHandle[]>();
 
         for (String path: modsFound) {
-            FileHandle modFile = Game.getInternal(path + "/" + folder);
+            FileHandle modFile = Game.resolveFile(path + "/" + folder);
             if (modFile.exists() && modFile.isDirectory()) {
                 FileHandle[] files = findRecursively(modFile, suffix);
                 if(files.length > 0) {
@@ -501,7 +501,7 @@ public class ModManager {
     public Array<FileHandle> getFileInAllMods(String file) {
         Array<FileHandle> files = new Array<FileHandle>();
         for (String path: modsFound) {
-            FileHandle modFile = Game.getInternal(path + "/" + file);
+            FileHandle modFile = Game.resolveFile(path + "/" + file);
             if (modFile.exists()) {
                 files.add(modFile);
             }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/generator/DungeonGenerator.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/generator/DungeonGenerator.java
@@ -24,41 +24,41 @@ import java.util.Random;
 public class DungeonGenerator {
 	private int MAPSIZE = 4;
 	private int TILESIZE = 17;
-	
+
 	public Integer width = null;
 	public Integer height = null;
-	
+
 	private GenTile[] genTiles = null;
 	private Boolean[] visited = null;
-	
+
 	private Random r;
 	private int maxComplexity = 1;
 	private int curComplexity = 0;
-	
+
 	private int dungeonLevel;
-	
+
 	private HashMap<String, Level> tileCache = new HashMap<String, Level>();
-	
+
 	public DungeonGenerator(Random r, int dungeonLevel) {
 		this.dungeonLevel = dungeonLevel;
 		this.r = r;
 	}
-	
+
 	public static String GetThemeDir(String type) {
 		char[] typeDirChars = type.toLowerCase().toCharArray();
 		typeDirChars[0] = Character.toUpperCase(typeDirChars[0]);
 		String theme = String.valueOf(typeDirChars);
-		
+
 		String themeDir = "generator/" + theme + "/";
-		
+
 		Gdx.app.log("DelverGenerator", "Using theme dir " + themeDir);
-		
+
 		return themeDir;
 	}
-	
+
 	public static GenTheme GetGenData(String type) {
 		String tilesDir = GetThemeDir(type);
-		
+
 		try {
 			GenTheme generatorTheme = Game.modManager.loadTheme(tilesDir + "info.dat");
 			return generatorTheme;
@@ -67,9 +67,9 @@ public class DungeonGenerator {
 			return new GenTheme();
 		}
 	}
-	
+
 	public Level MakeDungeon(String type) { return MakeDungeon(type, null, 0.7f, null); }
-	
+
 	public Level MakeDungeon(String type, String roomGeneratorType, float roomGeneratorChance, Progression progression) {
 		String tilesDir = GetThemeDir(type);
 		String cornersDir = tilesDir + "Corners/";
@@ -79,7 +79,7 @@ public class DungeonGenerator {
 		String beginningsDir = tilesDir + "Beginnings/";
 		String startsDir = tilesDir + "Starts/";
 		String endsDir = tilesDir + "Ends/";
-		
+
 		HashMap<TileTypes,ArrayMap<String, FileHandle>> tiles = new HashMap<TileTypes,ArrayMap<String, FileHandle>>();
 		tiles.put(TileTypes.beginning, getLevelFilesInDir(beginningsDir));
 		tiles.put(TileTypes.start, getLevelFilesInDir(startsDir));
@@ -110,7 +110,7 @@ public class DungeonGenerator {
 
 		// generate the map!
 		makeGenTiles(tiles, progression, type);
-		
+
 		for(int x = 0; x < MAPSIZE; x++) {
 			for(int y = 0; y < MAPSIZE; y++) {
 				GenTile tile = genTiles[x + y * MAPSIZE];
@@ -148,15 +148,15 @@ public class DungeonGenerator {
 
 					if(!generatedRoom && tile_entries != null) {
 						FileHandle level_tile_entry = null;
-						
+
 						// go pick a tile
 						int pick_tries = 0;
 						while(level_tile_entry == null) {
 							pick_tries++;
-							
+
 							// grab a random one
 							level_tile_entry = tile_entries.getValueAt(r.nextInt(tile_entries.size));
-						
+
 							// check if this tile is unique
 							if(progression != null && pick_tries < 10) {
 								if(level_tile_entry.name().contains("_unique")) {
@@ -181,16 +181,16 @@ public class DungeonGenerator {
 						else if(level_tile_entry.name().endsWith(".bin")) {
                             level_tile = KryoSerializer.loadLevel(level_tile_entry.readBytes());
 						}
-						
+
 						if(level_tile.width != TILESIZE || level_tile.height != TILESIZE) {
 							Gdx.app.log("Delver", "Invalid tile size: " + level_tile_entry + " - was expecting a size of " + TILESIZE + "x" + TILESIZE + " but got " + level_tile.width + "x" + level_tile.height);
 						}
-						
+
 						// rotate
 						for(int i = 0; i < tile.rot; i++) {
 							level_tile.rotate90();
 						}
-						
+
 						Gdx.app.log("DelverGenerator", "Added tile " + level_tile_entry.path());
 					}
 
@@ -225,9 +225,9 @@ public class DungeonGenerator {
 			EditorMarker marker = generated.editorMarkers.get(i);
 			generated.lockTilesAround(new Vector2(marker.x, marker.y), 8);
 		}
-		
+
 		tileCache.clear();
-		
+
 		return generated;
 	}
 
@@ -254,12 +254,12 @@ public class DungeonGenerator {
 	}
 
 	private Door addDoorAt(Level generating, Level generatorTile, float doorLocX, float doorLocY, DoorDirection direction) {
-		
+
 		Door doorDefinition = generating.genTheme.doors.get(Game.rand.nextInt(generating.genTheme.doors.size));
-		
+
 		if(doorDefinition != null) {
 			Door door = new Door(doorDefinition);
-			
+
 			Tile t = generatorTile.getTileOrNull(0, 8);
 			if(door != null && t != null) {
 				door.x = doorLocX;
@@ -267,13 +267,13 @@ public class DungeonGenerator {
 				door.z = 0;
 				door.doorDirection = direction;
 				door.isDynamic = true;
-				
+
 				if(direction == DoorDirection.EAST || direction == DoorDirection.WEST) {
 					float tempColX = door.collision.x;
 					door.collision.x = door.collision.y;
 					door.collision.y = tempColX;
 				}
-				
+
 				// Add this new door if there are no doors already there
 				if(generating.findEntities(Door.class, new Vector2(doorLocX, doorLocY), 1f, true, false, false).size == 0) {
 					generating.entities.add(door);
@@ -281,10 +281,10 @@ public class DungeonGenerator {
 				}
 			}
 		}
-		
+
 		return null;
 	}
-	
+
 	private void genTiles(HashMap<TileTypes,ArrayMap<String, FileHandle>> tiles, Progression progression, String theme) {
 		int genRound = 0;
 
@@ -295,7 +295,7 @@ public class DungeonGenerator {
 			genTileAt(TileTypes.beginning, Game.rand.nextInt(3), 1, Game.rand.nextInt(MAPSIZE), Game.rand.nextInt(MAPSIZE));
 		else
 			genTileAt(TileTypes.start, Game.rand.nextInt(3), 1, Game.rand.nextInt(MAPSIZE), Game.rand.nextInt(MAPSIZE));
-		
+
 		while(doGenRound(genRound++)) { }
 
 		pickFinishTile();
@@ -318,7 +318,7 @@ public class DungeonGenerator {
 			choice.type = TileTypes.finish;
 		}
 	}
-	
+
 	private Boolean doGenRound(int genRound) {
 		for(int x = 0; x < MAPSIZE; x++) {
 			for(int y = 0; y < MAPSIZE; y++) {
@@ -328,20 +328,20 @@ public class DungeonGenerator {
 				}
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	public Boolean findTileFor(int x, int y, int genRound) {
-		
+
 		List<GenTile> canPlaceList = new ArrayList<GenTile>();
-		
+
 		List<TileTypes> availableTiles = getAvailableTiles(genRound);
 		for(TileTypes type : availableTiles) {
 			for(int i = 0; i < 4; i++) {
 				GenTile tryTile = new GenTile(type, i, 2);
 				boolean canPlace = true;
-				
+
 				GenTile up = getTileAt(x, y - 1);
 				GenTile down = getTileAt(x, y + 1);
 				GenTile left = getTileAt(x - 1, y);
@@ -359,46 +359,46 @@ public class DungeonGenerator {
 				if(right != null && right.exitLeft != tryTile.exitRight) {
 					canPlace = false;
 				}
-				
+
 				if(tryTile.exitTop && isOutOfBounds(x, y - 1)) canPlace = false;
 				else if(tryTile.exitBottom && isOutOfBounds(x, y + 1)) canPlace = false;
 				else if(tryTile.exitLeft && isOutOfBounds(x - 1, y)) canPlace = false;
 				else if(tryTile.exitRight && isOutOfBounds(x + 1, y)) canPlace = false;
-				
+
 				if(canPlace)
 					canPlaceList.add(tryTile);
 			}
 		}
-		
+
 		if(canPlaceList.size() > 0) {
 			GenTile gen = canPlaceList.get(r.nextInt( canPlaceList.size() ));
 			genTileAt(gen.type, gen.rot, 2, x, y);
-			
+
 			if(gen.type == TileTypes.intersection)
 				curComplexity += 2;
 			if(gen.type == TileTypes.tri_intersection)
 				curComplexity += 1;
-			
+
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	private Boolean isOutOfBounds(int x, int y) {
 		if(x < 0 || x >= MAPSIZE || y < 0 || y >= MAPSIZE) return true;
 		return false;
 	}
-	
+
 	private Boolean doConnect(int rot1, int exits1, int rot2, int exits2) {
 		return false;
 	}
-	
+
 	private void genTileAt(TileTypes type, int rot, int exits, int x, int y) {
 		GenTile t = new GenTile(type, rot, exits);
 		genTiles[x + y * MAPSIZE] = t;
 		visited[x + y * MAPSIZE] = true;
-		
+
 		if(t.exitLeft && !isOutOfBounds(x - 1, y) && getVisited(x - 1, y) != true)
 			setVisited(false, x - 1, y);
 		if(t.exitTop && !isOutOfBounds(x, y - 1) && getVisited(x, y - 1) != true)
@@ -408,42 +408,42 @@ public class DungeonGenerator {
 		if(t.exitBottom && !isOutOfBounds(x, y + 1) && getVisited(x, y + 1) != true)
 			setVisited(false, x, y + 1);
 	}
-	
+
 	private GenTile getTileAt(int x, int y) {
 		if(x >= 0 && x < MAPSIZE && y >= 0 && y < MAPSIZE)
 			return genTiles[x + y * MAPSIZE];
-		
+
 		return null;
 	}
 
 	private void replaceTile(int x, int y, GenTile tile)  {
 		genTiles[x + y * MAPSIZE] = tile;
 	}
-	
+
 	private void setVisited(Boolean val, int x, int y) {
 		if(x >= 0 && x < MAPSIZE && y >= 0 && y < MAPSIZE)
 			visited[x + y * MAPSIZE] = val;
 	}
-	
+
 	private Boolean getVisited(int x, int y) {
 		if (visited[x + y * MAPSIZE] == null) return false;
 		return visited[x + y * MAPSIZE];
 	}
-	
+
 	private List<TileTypes> getAvailableTiles(int genRound) {
 		List<TileTypes> availableTiles = new ArrayList<TileTypes>();
-		
+
 		availableTiles.add(TileTypes.corner);
 		availableTiles.add(TileTypes.hall);
-		
+
 		if(maxComplexity > 0 && curComplexity < maxComplexity) {
 			availableTiles.add(TileTypes.intersection);
 			availableTiles.add(TileTypes.tri_intersection);
 		}
-		
+
 		if(genRound > 2)
 			availableTiles.add(TileTypes.end);
-		
+
 		return availableTiles;
 	}
 
@@ -455,7 +455,7 @@ public class DungeonGenerator {
 
             Gdx.app.debug("Delver", "Looking for generator pieces in: " + genFolder);
 
-            FileHandle gf = Game.getInternal(genFolder);
+            FileHandle gf = Game.resolveFile(genFolder);
             if(gf.exists()) {
                 for(FileHandle entry : Game.listDirectory(gf)) {
                     if ((entry.name().endsWith(".dat") || entry.name().endsWith(".bin") || entry.name().endsWith(".json"))) {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/ui/UiSkin.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/ui/UiSkin.java
@@ -3,41 +3,38 @@ package com.interrupt.dungeoneer.ui;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
-import com.badlogic.gdx.graphics.g2d.NinePatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
-import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.ui.Label.LabelStyle;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
-import com.badlogic.gdx.utils.Json;
 import com.interrupt.dungeoneer.Art;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Options;
 
 public class UiSkin {
-	
+
 	private static Skin skin;
     private static BitmapFont font;
-    
+
     public static Skin getSkin() {
     	if(skin == null) loadSkin();
     	//font.setScale(1f);
     	return skin;
     }
-    
+
     public static BitmapFont getFont() {
     	if(font == null) loadSkin();
     	//font.setScale(1f);
     	return font;
     }
-    
+
     public static void loadSkin() {
     	Texture t = Art.loadTexture("ui/skin.png");
 		TextureAtlas atlas = new TextureAtlas();
 		TextureAtlas.AtlasRegion upRegion = atlas.addRegion("up", t, 0, 0, 48, 16);
 		TextureAtlas.AtlasRegion downRegion = atlas.addRegion("down", t, 0, 16, 48, 16);
 		atlas.addRegion("slider", t, 16, 32, 48, 16);
-		
+
 		atlas.addRegion("check-on", t, 0, 32, 16, 16);
 		atlas.addRegion("check-off", t, 0, 48, 16, 16);
 		atlas.addRegion("sliderKnob", t, 16, 48, 16, 16);
@@ -51,7 +48,7 @@ public class UiSkin {
         Texture tooltipTexture = Art.loadTexture("ui/tooltip.png");
 		Texture tableHover = Art.loadTexture("ui/table-hover.png");
 		Texture tableNoHover = Art.loadTexture("ui/table-no-hover.png");
-		
+
 		atlas.addRegion("window", windowTexture, 0, 0, windowTexture.getWidth(), windowTexture.getHeight());
 		TextureAtlas.AtlasRegion tooltipRegion = atlas.addRegion("tooltip-window", tooltipTexture, 0, 0, tooltipTexture.getWidth(), tooltipTexture.getHeight());
 		atlas.addRegion("note-window", noteTexture, 0, 0, noteTexture.getWidth(), noteTexture.getHeight());
@@ -82,7 +79,7 @@ public class UiSkin {
 		tableNoHoverAtlas.splits = new int[]{1, 1, 1, 1};
 		tableNoHoverAtlas.pads = new int[]{4, 1, 4, 2};
 
-		skin = new Skin(Game.getInternal("ui/skin.json"), atlas);
+		skin = new Skin(Game.resolveFile("ui/skin.json"), atlas);
 
 		t.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
 
@@ -132,13 +129,13 @@ public class UiSkin {
 			}
 		}
     }
-    
+
     public static void clearCache() {
     	if(skin != null) {
     		//skin.dispose();
     		skin = null;
     	}
-    	
+
     	if(font != null) {
     		//font.dispose();
     		font = null;

--- a/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
+++ b/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
@@ -87,23 +87,25 @@ public class ZipFileHandle extends FileHandle {
 
     @Override
     public FileHandle[] list() {
-        String name = entry.getName();
-        Path base = Paths.get(name);
+        Path basePath = Paths.get(entry.getName());
 
         Array<String> children = new Array<>();
-        for (String e : entries) {
-            if (e.startsWith(name) && !e.equals(name)) {
-                Path relative = base.relativize(Paths.get(e));
-                Path firstPart = relative.subpath(0, 1);
-                Path child = base.resolve(firstPart);
-                String cs = child.toString();
+        for (String entry : entries) {
+            Path entryPath = Paths.get(entry);
 
-                if (cs.length() < e.length()) {
-                    int i = cs.length();
-                    if (e.charAt(i) == '/') cs += "/";
+            if (isChildPath(basePath, entryPath)) {
+                Path relativePath = basePath.relativize(entryPath);
+                Path firstPart = relativePath.subpath(0, 1);
+                String child = basePath.resolve(firstPart).toString();
+
+                if (child.length() < entry.length()) {
+                    int i = child.length();
+                    if (entry.charAt(i) == '/') child += "/";
                 }
 
-                if (!children.contains(cs, false)) children.add(cs);
+                if (!children.contains(child, false)) {
+                    children.add(child);
+                }
             }
         }
 
@@ -113,6 +115,10 @@ public class ZipFileHandle extends FileHandle {
         }
 
         return result;
+    }
+
+    private boolean isChildPath(Path parent, Path child) {
+        return child.startsWith(parent) && !child.equals(parent);
     }
 
     @Override

--- a/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
+++ b/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
@@ -1,0 +1,146 @@
+package com.interrupt.files;
+
+import com.badlogic.gdx.Files;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class ZipFileHandle extends FileHandle {
+    private final ZipFile archive;
+    private ZipEntry entry;
+    private final Array<String> entries;
+
+    public ZipFileHandle(ZipFile archive, File file, String name) {
+        super(file, Files.FileType.Internal);
+        this.archive = archive;
+        entry = archive.getEntry(name);
+        if (entry == null) {
+            entry = new ZipEntry(name);
+        }
+
+        entries = new Array<>();
+        Enumeration<? extends ZipEntry> es = archive.entries();
+        while (es.hasMoreElements()) {
+            entries.add(es.nextElement().getName());
+        }
+    }
+
+    @Override
+    public String path() {
+        return file.getPath().replace("\\", "/") + "/" + entry.getName();
+    }
+
+    @Override
+    public String name() {
+        String path = path();
+        int index = path.lastIndexOf('/');
+        if (index < 0) return path;
+        return path.substring(index + 1);
+    }
+
+    @Override
+    public String extension() {
+        String name = name();
+        int dotIndex = name.lastIndexOf('.');
+        if (dotIndex == -1) return "";
+        return name.substring(dotIndex + 1);
+    }
+
+    @Override
+    public String nameWithoutExtension() {
+        String name = name();
+        int dotIndex = name.lastIndexOf('.');
+        if (dotIndex == -1) return name;
+        return name.substring(0, dotIndex);
+    }
+
+    @Override
+    public String pathWithoutExtension() {
+        String path = path();
+        int dotIndex = path.lastIndexOf('.');
+        if (dotIndex == -1) return path;
+        return path.substring(0, dotIndex);
+    }
+
+    @Override
+    public boolean exists() {
+        return entries.contains(entry.getName(), false);
+    }
+
+    @Override
+    public long length() {
+        return entry.getSize();
+    }
+
+    @Override
+    public long lastModified() {
+        return entry.getTime();
+    }
+
+    @Override
+    public InputStream read() {
+        try {
+            return archive.getInputStream(entry);
+        }
+        catch (Exception ignored) {}
+
+        return null;
+    }
+
+    @Override
+    public ByteBuffer map(FileChannel.MapMode mode) {
+        throw new GdxRuntimeException("Cannot map a ZipFileHandle");
+    }
+
+    @Override
+    public OutputStream write(boolean append) {
+        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+    }
+
+    @Override
+    public void write(InputStream input, boolean append) {
+        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+    }
+
+    @Override
+    public Writer writer(boolean append) {
+        return writer(append, null);
+    }
+
+    @Override
+    public Writer writer(boolean append, String charset) {
+        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+    }
+
+    @Override
+    public void writeString(String string, boolean append) {
+        writeString(string, append, null);
+    }
+
+    @Override
+    public void writeString(String string, boolean append, String charset) {
+        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+    }
+
+    @Override
+    public void writeBytes(byte[] bytes, boolean append) {
+        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+    }
+
+    @Override
+    public void writeBytes(byte[] bytes, int offset, int length, boolean append) {
+        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return entry.isDirectory();
+    }
+}

--- a/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
+++ b/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
@@ -93,12 +93,12 @@ public class ZipFileHandle extends FileHandle {
     }
 
     @Override
-    public ByteBuffer map () {
+    public ByteBuffer map() {
         throw new GdxRuntimeException("Error ZipFileHandle objects do not support memory mapping");
     }
 
     @Override
-    public ByteBuffer map (FileChannel.MapMode mode) {
+    public ByteBuffer map(FileChannel.MapMode mode) {
         throw new GdxRuntimeException("Error ZipFileHandle objects do not support memory mapping");
     }
 
@@ -175,17 +175,17 @@ public class ZipFileHandle extends FileHandle {
     }
 
     @Override
-    public FileHandle[] list (FileFilter filter) {
+    public FileHandle[] list(FileFilter filter) {
         throw new GdxRuntimeException("Unsupported method");
     }
 
     @Override
-    public FileHandle[] list (FilenameFilter filter) {
+    public FileHandle[] list(FilenameFilter filter) {
         throw new GdxRuntimeException("Unsupported method");
     }
 
     @Override
-    public FileHandle[] list (String suffix) {
+    public FileHandle[] list(String suffix) {
         throw new GdxRuntimeException("Unsupported method");
     }
 
@@ -234,6 +234,7 @@ public class ZipFileHandle extends FileHandle {
     public void emptyDirectory() {
         throw new GdxRuntimeException("Unsupported method");
     }
+
     @Override
     public void emptyDirectory(boolean preserveTree) {
         throw new GdxRuntimeException("Unsupported method");
@@ -263,7 +264,8 @@ public class ZipFileHandle extends FileHandle {
         int i = name.indexOf(".zip") + ".zip".length();
         String zipFilePath = name.substring(0, i);
         String zipEntryName = name.substring(i);
-        if (zipEntryName.startsWith("/")) zipEntryName = zipEntryName.substring(1);
+        if (zipEntryName.startsWith("/"))
+            zipEntryName = zipEntryName.substring(1);
 
         try {
             FileHandle f = Gdx.files.internal(zipFilePath);

--- a/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
+++ b/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
@@ -4,7 +4,6 @@ import com.badlogic.gdx.Files;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.GdxRuntimeException;
 
 import java.io.*;
 import java.nio.ByteBuffer;
@@ -80,7 +79,7 @@ public class ZipFileHandle extends FileHandle {
 
     @Override
     public File file() {
-        throw new GdxRuntimeException("Cannot get a FileHandle for a ZipFileHandle object");
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -95,22 +94,22 @@ public class ZipFileHandle extends FileHandle {
 
     @Override
     public ByteBuffer map() {
-        throw new GdxRuntimeException("Error ZipFileHandle objects do not support memory mapping");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public ByteBuffer map(FileChannel.MapMode mode) {
-        throw new GdxRuntimeException("Error ZipFileHandle objects do not support memory mapping");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public OutputStream write(boolean append) {
-        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void write(InputStream input, boolean append) {
-        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -120,7 +119,7 @@ public class ZipFileHandle extends FileHandle {
 
     @Override
     public Writer writer(boolean append, String charset) {
-        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -130,17 +129,17 @@ public class ZipFileHandle extends FileHandle {
 
     @Override
     public void writeString(String string, boolean append, String charset) {
-        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void writeBytes(byte[] bytes, boolean append) {
-        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void writeBytes(byte[] bytes, int offset, int length, boolean append) {
-        throw new GdxRuntimeException("Cannot write to a ZipFileHandle");
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -177,12 +176,12 @@ public class ZipFileHandle extends FileHandle {
 
     @Override
     public FileHandle[] list(FileFilter filter) {
-        throw new GdxRuntimeException("Unsupported method");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public FileHandle[] list(FilenameFilter filter) {
-        throw new GdxRuntimeException("Unsupported method");
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -195,11 +194,12 @@ public class ZipFileHandle extends FileHandle {
 
             if (!entryPath.startsWith(basePath)) continue;
             if (entryPath.equals(basePath)) continue;
-            if (!entry.endsWith(suffix)) continue;
 
             Path relativePath = basePath.relativize(entryPath);
             Path firstPart = relativePath.subpath(0, 1);
             String child = basePath.resolve(firstPart).toString().replace("\\", "/");
+
+            if (!child.endsWith(suffix)) continue;
 
             if (child.length() < entry.length()) {
                 int i = child.length();
@@ -242,7 +242,7 @@ public class ZipFileHandle extends FileHandle {
 
     @Override
     public void mkdirs() {
-        throw new GdxRuntimeException("Unsupported method");
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -252,22 +252,22 @@ public class ZipFileHandle extends FileHandle {
 
     @Override
     public boolean delete() {
-        throw new GdxRuntimeException("Unsupported method");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean deleteDirectory() {
-        throw new GdxRuntimeException("Unsupported method");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void emptyDirectory() {
-        throw new GdxRuntimeException("Unsupported method");
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void emptyDirectory(boolean preserveTree) {
-        throw new GdxRuntimeException("Unsupported method");
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
+++ b/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
@@ -249,14 +249,6 @@ public class ZipFileHandle extends FileHandle {
     }
 
     @Override
-    public int hashCode () {
-        int hash = 1;
-        hash = hash * 37 + type.hashCode();
-        hash = hash * 67 + path().hashCode();
-        return hash;
-    }
-
-    @Override
     public String toString() {
         return (file.getPath() + "/" + entry.getName()).replace('\\', '/');
     }

--- a/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
+++ b/Dungeoneer/src/com/interrupt/files/ZipFileHandle.java
@@ -1,6 +1,7 @@
 package com.interrupt.files;
 
 import com.badlogic.gdx.Files;
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -251,5 +252,28 @@ public class ZipFileHandle extends FileHandle {
     @Override
     public String toString() {
         return (file.getPath() + "/" + entry.getName()).replace('\\', '/');
+    }
+
+    /** Returns a ZipFileHandle for an asset inside a zip file. */
+    static public FileHandle get(String name) {
+        FileHandle handle = Gdx.files.internal(name);
+
+        if (!name.contains(".zip")) return handle;
+
+        int i = name.indexOf(".zip") + ".zip".length();
+        String zipFilePath = name.substring(0, i);
+        String zipEntryName = name.substring(i);
+        if (zipEntryName.startsWith("/")) zipEntryName = zipEntryName.substring(1);
+
+        try {
+            FileHandle f = Gdx.files.internal(zipFilePath);
+            ZipFile z = new ZipFile(f.file());
+            handle = new ZipFileHandle(z, f.file(), zipEntryName);
+        }
+        catch (Exception ignored) {
+            Gdx.app.debug("Delver", "Unable to open zip: " + zipFilePath);
+        }
+
+        return handle;
     }
 }


### PR DESCRIPTION
## Summary
Allows for mod assets to be loaded from inside a zip file. Implements #236 

## Changes
- Implemented a `ZipFileHandler` class 
- Added logic to `Game.getInternal()` to detect if a zip file is part of the path and returns a `ZipFileHander` object.
- Added support to load assets from an `assets.zip` file
- Deprecated `Game.getInternal()`
- Renamed `Game.getInternal()` to `Game.resolveFile()`

## Testing
I've currently only tested this with the Guns mod zipped up and put in my repo's mod folder.