### PR TITLE
Vertical Pause Menu Layout + String Table Fix

### DIFF
--- a/Dungeoneer/assets/data/strings.dat
+++ b/Dungeoneer/assets/data/strings.dat
@@ -530,9 +530,14 @@
         "localizedName": "CLOSE",
         "comment": "Text for the close button on the message overlay."
     },
-    "overlays.PauseOverlay.backButton": {
+    "overlays.ModsOverlay.backButton": {
         "class": "com.interrupt.dungeoneer.game.LocalizedString",
         "localizedName": "Back",
+        "comment": "Text for the back button mod manager."
+    },
+    "overlays.PauseOverlay.backButton": {
+        "class": "com.interrupt.dungeoneer.game.LocalizedString",
+        "localizedName": "Resume",
         "comment": "Text for the back button on the pause screen. Goes back to playing the game."
     },
     "overlays.PauseOverlay.quitButton": {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/overlays/ModsOverlay.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/overlays/ModsOverlay.java
@@ -1,7 +1,6 @@
 package com.interrupt.dungeoneer.overlays;
 
 import com.badlogic.gdx.Input.Keys;
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
@@ -10,11 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Array;
-import com.interrupt.dungeoneer.Audio;
-import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.game.Game;
-import com.interrupt.dungeoneer.game.ModManager;
-import com.interrupt.dungeoneer.input.Actions;
 import com.interrupt.managers.StringManager;
 
 public class ModsOverlay extends WindowOverlay {
@@ -54,7 +49,7 @@ public class ModsOverlay extends WindowOverlay {
 
 		final Overlay thisOverlay = this;
 
-		TextButton backBtn = new TextButton(" " + StringManager.get("overlays.PauseOverlay.backButton") + " ", skin.get(TextButtonStyle.class));
+		TextButton backBtn = new TextButton(" " + StringManager.get("overlays.ModsOverlay.backButton") + " ", skin.get(TextButtonStyle.class));
 		backBtn.addListener(new ClickListener() {
 			@Override
 			public void clicked(InputEvent event, float x, float y) {
@@ -62,7 +57,7 @@ public class ModsOverlay extends WindowOverlay {
 				OverlayManager.instance.remove(thisOverlay);
 			}
 		});
-		
+
 		Table contentTable = new Table();
 
 	    Label headerText = new Label("Manage Mods",skin.get(LabelStyle.class));
@@ -109,14 +104,14 @@ public class ModsOverlay extends WindowOverlay {
 		}
 
 		contentTable.add(scrollPane).fillX().expand().maxHeight(135).row();
-	    
+
 	    contentTable.add(backBtn).align(Align.left).expand().padTop(8);
 
 	    ui.setScrollFocus(scrollPane);
-	    
+
 	    buttonOrder.clear();
 	    buttonOrder.add(backBtn);
-		
+
 		return contentTable;
 	}
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/overlays/PauseOverlay.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/overlays/PauseOverlay.java
@@ -4,20 +4,19 @@ import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Label.LabelStyle;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.badlogic.gdx.scenes.scene2d.ui.Label.LabelStyle;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.interrupt.dungeoneer.Audio;
 import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.input.Actions;
-import com.interrupt.dungeoneer.input.ControllerState;
 import com.interrupt.managers.StringManager;
 
 public class PauseOverlay extends WindowOverlay {
-	
+
 	public PauseOverlay() { }
 
 	@Override
@@ -35,7 +34,7 @@ public class PauseOverlay extends WindowOverlay {
 	public void onShow() {
 		super.onShow();
 		Audio.setMusicVolume(0.3f);
-		
+
 		final Overlay thisOverlay = this;
 		InputListener listener = new com.badlogic.gdx.scenes.scene2d.InputListener() {
 			@Override
@@ -57,9 +56,9 @@ public class PauseOverlay extends WindowOverlay {
 
 	@Override
 	public Table makeContent() {
-		
+
 		final Overlay thisOverlay = this;
-		
+
 		TextButton backBtn = new TextButton(" " + StringManager.get("overlays.PauseOverlay.backButton") + " ", skin.get(TextButtonStyle.class));
 		backBtn.addListener(new ClickListener() {
 			@Override
@@ -76,7 +75,7 @@ public class PauseOverlay extends WindowOverlay {
 				OverlayManager.instance.push(new OptionsOverlay());
 			}
 		});
-		
+
 		TextButton controlsBtn = new TextButton(" " + StringManager.get("overlays.PauseOverlay.quitButton") + " ", skin.get(TextButtonStyle.class));
 		controlsBtn.addListener(new ClickListener() {
 			@Override
@@ -85,24 +84,23 @@ public class PauseOverlay extends WindowOverlay {
 				GameApplication.ShowMainMenuScreen();
 			}
 		});
-		
+
 		Table contentTable = new Table();
 	    Label pauseText = new Label(StringManager.get("overlays.PauseOverlay.pauseHeader"),skin.get(LabelStyle.class));
-	    contentTable.add(pauseText);
+	    contentTable.add(pauseText).padBottom(8f);
 	    contentTable.row();
-	    
-	    contentTable.add(backBtn);
-		contentTable.add(optionsBtn).padLeft(4).padRight(4);
-	    contentTable.add(controlsBtn);
-	    
-	    contentTable.getCell(pauseText).padBottom(8f).colspan(3);
-	    contentTable.getCell(backBtn);
-	    
+
+	    contentTable.add(backBtn).padBottom(1f).fillX();
+	    contentTable.row();
+		contentTable.add(optionsBtn).padBottom(1f).fillX();
+	    contentTable.row();
+	    contentTable.add(controlsBtn).fillX();
+
 	    buttonOrder.clear();
 	    buttonOrder.add(backBtn);
 	    buttonOrder.add(optionsBtn);
 	    buttonOrder.add(controlsBtn);
-		
+
 		return contentTable;
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/372642/117353879-8b7bac00-ae65-11eb-8f5d-6dd8cdae2d11.png)
## Summary
Adjusts pause menu to a more standard vertical layout.

## Changes
- Pause buttons use vertical layout
- ModManager no longer reuses Pause Menu back text.
- Pause menu back text changed to "Resume"