### PR TITLE
Crosshair HUD Extraction - OLD Approach

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Item.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Item.java
@@ -142,6 +142,10 @@ public class Item extends Entity {
 	public transient String lastMeshFile = null;
 	public transient String lastTextureFile = null;
 
+    /** Should we draw a crosshair for this item when being equipped? */
+    @EditorProperty(group = "HUD")
+    public boolean showCrosshair = false;
+
 	private static final transient Entity pickupHelper = new Entity();
 
 	public Item() {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Bow.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Bow.java
@@ -24,10 +24,20 @@ public class Bow extends Weapon {
 	@EditorProperty
 	public String fireSound = "bow.mp3,bow_02.mp3,bow_03.mp3,bow_04.mp3";
 
-	public Bow() { super(0, 0, 15, ItemType.bow, StringManager.get("items.Bow.defaultName")); this.yOffset = 0.085f; attackAnimation = "bowAttack"; chargeAnimation = "bowCharge"; shadowType = ShadowType.BLOB;  }
+	public Bow() {
+        super(0, 0, 15, ItemType.bow, StringManager.get("items.Bow.defaultName"));
+
+        this.yOffset = 0.085f;
+        attackAnimation = "bowAttack";
+        chargeAnimation = "bowCharge";
+        shadowType = ShadowType.BLOB;
+        showCrosshair = true;
+    }
 
 	public Bow(float x, float y) {
 		super(x, y, 15, ItemType.bow, StringManager.get("items.Bow.defaultName"));
+
+        showCrosshair = true;
 	}
 
 	public String GetInfoText() {
@@ -45,7 +55,7 @@ public class Bow extends Weapon {
 
 		int damageRoll = doAttackRoll(attackPower, p);
 		if(damageRoll == 0) damageRoll = 1;
-		
+
 		float power = attackPower * (this.range / 4.0f) * 0.5f;
 		missile.isActive = true;
 		missile.isDynamic = true;
@@ -76,7 +86,7 @@ public class Bow extends Weapon {
 		}
 
 		lvl.entities.add(missile);
-		
+
 		Audio.playSound(fireSound, 0.25f);
 	}
 
@@ -101,7 +111,7 @@ public class Bow extends Weapon {
 		}
 		return null;
 	}
-	
+
 	public Missile getAmmo() {
 		Item found = findAmmo();
 		if(found != null) {
@@ -120,7 +130,7 @@ public class Bow extends Weapon {
 		}
 		return null;
 	}
-	
+
 	@Override
 	public Integer getHeldTex() {
 		Item found = findAmmo();

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Wand.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/items/Wand.java
@@ -30,7 +30,7 @@ public class Wand extends Weapon {
     /** Require charges to fire? */
 	@EditorProperty
 	public boolean usesCharges = true;
-	
+
 	private transient int lastComputedChargeValue = 0;
 	private transient String chargeText = "0";
 
@@ -52,25 +52,32 @@ public class Wand extends Weapon {
 	private transient Particle chargeEffect = null;
 	private float chargeTime = 0f;
 
-    public Wand() { attackAnimation = "wandAttack"; chargeAnimation = "wandCharge"; equipSound = "/ui/ui_equip_item.mp3"; }
+    public Wand() {
+        attackAnimation = "wandAttack";
+        chargeAnimation = "wandCharge";
+        equipSound = "/ui/ui_equip_item.mp3";
+        showCrosshair = true;
+    }
 
 	public Wand(float x, float y) {
-		super(x, y, 16, ItemType.wand, StringManager.get("items.Wand.defaultNameText"));
-		charges = 5;
-	}
-	
+        super(x, y, 16, ItemType.wand, StringManager.get("items.Wand.defaultNameText"));
+
+        charges = 5;
+        showCrosshair = true;
+    }
+
 	public Color getColor()
 	{
 		return Weapon.getEnchantmentColor(this.damageType);
 	}
-	
+
 	public String GetInfoText() {
 		if(usesCharges)
 			return MessageFormat.format(StringManager.get("items.Wand.infoText"), getChargeNumber(Game.instance.player)) + "\n" + super.GetInfoText();
 		else
 			return super.GetInfoText();
 	}
-	
+
 	@Override
 	public void doAttack(Player p, Level lvl, float attackPower) {
 
@@ -93,12 +100,12 @@ public class Wand extends Weapon {
 
 		Vector3 direction = getCrosshairDirection(-0.3f);
 		if(direction == null) direction = Game.camera.direction;
-		
+
 		spell.damageType = damageType;
 		spell.baseDamage = getBaseDamage();
 		spell.randDamage = getRandDamage();
 		spell.zap(p, direction.cpy(), new Vector3(x + direction.x * 0.15f, y + direction.z * 0.15f, z + direction.y * 0.15f));
-		
+
 		p.history.usedWand(this);
 
 		if(autoFire)
@@ -116,14 +123,14 @@ public class Wand extends Weapon {
 		}
 		return super.getRandDamage() + boost;
 	}
-	
+
 	public int getChargeNumber(Player p) {
 		if(!usesCharges)
 			return 1;
 
 		return charges + (int)(p.getMagicStatBoost() * magicStatBoostMod);
 	}
-	
+
 	public String getChargeText() {
 
 		if(!usesCharges)

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -555,6 +555,7 @@ public class Game {
         hudManager.quickSlots.tickUI(input);
 		hudManager.backpack.tickUI(input);
 		hud.tick(input);
+        hudManager.draw();
 
 		// keep the cache clean
 		CachePools.clearOnTick();

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -157,7 +157,6 @@ public class GlRenderer {
 	protected Color tempColor = new Color();
 	protected Color tempColor1 = new Color();
 	protected Color tempColor2 = new Color();
-	protected Color crosshairColor = new Color(1f,1f,1f,0.35f);
 
 	protected String keystr = "";
 	protected String lvlText = "";
@@ -666,8 +665,6 @@ public class GlRenderer {
 		uiBatch.setColor(Color.WHITE);
 
 		if(OverlayManager.instance.current() == null || !OverlayManager.instance.current().catchInput) {
-			drawCrosshair();
-
 			int textYPos = 0;
 			if (Game.messageTimer > 0 && !OverlayManager.instance.shouldPauseGame()) {
 				float fontSize = Math.min(camera2D.viewportWidth, camera2D.viewportHeight) / 15;
@@ -755,37 +752,6 @@ public class GlRenderer {
 			drawGamepadCursor();
 		}
 	}
-
-    private void drawCrosshair() {
-        if (!shouldDrawCrosshair()) {
-            return;
-        }
-
-        float crosshairSize = 18f;
-        drawText(
-            "+",
-            -0.5f * crosshairSize,
-            -0.65f * crosshairSize,
-            crosshairSize,
-            crosshairColor
-        );
-    }
-
-    private boolean shouldDrawCrosshair() {
-        Item held = game.player.GetHeldItem();
-        if (held == null) {
-            return false;
-        }
-
-        if (Options.instance.hideUI) {
-            return false;
-        }
-
-        return Options.instance.alwaysShowCrosshair
-            || held.itemType == Item.ItemType.bow
-            || held.itemType == Item.ItemType.junk
-            || held.itemType == Item.ItemType.wand;
-    }
 
 	public void updateShaderAttributes() {
 		Color ambientColor = Color.BLACK;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/ui/Crosshair.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/ui/Crosshair.java
@@ -1,0 +1,52 @@
+package com.interrupt.dungeoneer.ui;
+
+import com.badlogic.gdx.graphics.Color;
+import com.interrupt.dungeoneer.GameManager;
+import com.interrupt.dungeoneer.entities.Item;
+import com.interrupt.dungeoneer.game.Game;
+import com.interrupt.dungeoneer.game.Options;
+import com.interrupt.dungeoneer.overlays.OverlayManager;
+
+public class Crosshair implements IHUDRenderable {
+    private Color color = new Color(1f, 1f, 1f, 0.35f);
+    private float size = 18f;
+
+    public void draw() {
+        if (!shouldDrawCrosshair()) {
+            return;
+        }
+
+        GameManager.renderer.uiBatch.begin();
+        GameManager.renderer.uiBatch.setColor(Color.WHITE);
+        // TODO: Provide option to use texture instead?
+        GameManager.renderer.drawText("+", -0.5f * size, -0.65f * size, size, color);
+        GameManager.renderer.uiBatch.end();
+    }
+
+    private boolean shouldDrawCrosshair() {
+        // TODO: Provide a proper boolean for this on a state manager?
+        if (GameManager.renderer.cutsceneCamera != null && GameManager.renderer.cutsceneCamera.isActive) {
+            return false;
+        }
+
+        // TODO: Provide a proper boolean for this on a state manager?
+        if (OverlayManager.instance.current() != null && OverlayManager.instance.current().catchInput) {
+            return false;
+        }
+
+        if (Options.instance.hideUI) {
+            return false;
+        }
+
+        if (Options.instance.alwaysShowCrosshair) {
+            return true;
+        }
+
+        Item heldItem = Game.instance.player.GetHeldItem();
+        if (heldItem == null) {
+            return false;
+        }
+
+        return heldItem.showCrosshair;
+    }
+}

--- a/Dungeoneer/src/com/interrupt/dungeoneer/ui/IHUDRenderable.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/ui/IHUDRenderable.java
@@ -1,0 +1,5 @@
+package com.interrupt.dungeoneer.ui;
+
+public interface IHUDRenderable {
+    public void draw();
+}

--- a/Dungeoneer/src/com/interrupt/managers/HUDManager.java
+++ b/Dungeoneer/src/com/interrupt/managers/HUDManager.java
@@ -1,10 +1,14 @@
 package com.interrupt.managers;
 
+import com.badlogic.gdx.utils.Array;
 import com.interrupt.dungeoneer.ui.Hotbar;
+import com.interrupt.dungeoneer.ui.IHUDRenderable;
 
 public class HUDManager {
     public Hotbar quickSlots = new Hotbar(6, 1, 0);
     public Hotbar backpack = new Hotbar(6, 3, 6);
+
+    public Array<IHUDRenderable> renderables = new Array<>();
 
     public void merge(HUDManager other) {
         if (null != other.quickSlots) {
@@ -13,6 +17,16 @@ public class HUDManager {
 
         if (null != other.backpack) {
             backpack = other.backpack;
+        }
+
+        if (other.renderables.size > 0) {
+            renderables = other.renderables;
+        }
+    }
+
+    public void draw() {
+        for (IHUDRenderable renderable : renderables) {
+            renderable.draw();
         }
     }
 }


### PR DESCRIPTION
Extracts the current crosshair implementation and puts it into its own class that can be loaded into the HUD Manager.

I removed the hard-coded item type check with this PR. Instead, an item now needs to explicitly state when it wants us to render a crosshair for it when being used.