### PR TITLE
Adding spell support to guns

### DIFF
--- a/jsonschema/current/dungeoneer/entities/items/Gun.schema.json
+++ b/jsonschema/current/dungeoneer/entities/items/Gun.schema.json
@@ -83,6 +83,11 @@
             "$ref": "../projectiles/Projectile.schema.json",
             "baseClass": "Gun"
         },
+        "spell": {
+            "description": "Spell to fire. Will use hitscan if not set.",
+            "$ref": "../spells/Spell.schema.json",
+            "baseClass": "Gun"
+        },
         "baseMods": {
             "description": "Base modifiers",
             "$ref": "../items/ItemModification.schema.json",


### PR DESCRIPTION
![lighting_spell_gun](https://user-images.githubusercontent.com/372642/130728680-aa577822-c7d3-452e-af95-f029ff98272c.gif)
_A gun posing as wand that shoots two bolts of lightning per shot with a wide spread._

# Summary
Adds the ability for guns to fire spells. Functionality is similar to that of how projectiles work.