### PR TITLE
Fixing a segfault in the OSX editor app while rendering for picking

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/EditorApplication.java
@@ -1977,7 +1977,7 @@ public class EditorApplication implements ApplicationListener {
         if(pointBatch != null) pointBatch.dispose();
         pointBatch = new DecalBatch(new SpriteGroupStrategy(camera, null, GlRenderer.worldShaderInfo, 1));
 
-		pickerFrameBuffer = CreateFrameBuffer(pickerFrameBuffer, width, height, true, true);
+		pickerFrameBuffer = CreateFrameBuffer(pickerFrameBuffer, width, height, true, false);
 
 		if(pickerPixelBuffer != null)
 			pickerPixelBuffer.dispose();


### PR DESCRIPTION
For some reason creating the picker frame buffer with stencil support is causing a segfault on this M1 Macbook. This is another worrying sign of the OpenGL rot that is setting in on OSX lately, hopefully the work to add an ANGLE backend to LibGdx lands soon and we can try that as an alternative backend for OSX (and maybe all platforms)

LibGDX ANGLE backend PR
https://github.com/libgdx/libgdx/pull/6672