### PR TITLE
Letting a mod override all of the base game data, like an iWad would in Doom

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/GameData.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/GameData.java
@@ -26,6 +26,10 @@ public class GameData {
     /** Is player allowed to jump? */
     public boolean playerJumpEnabled = false;
 
+    /** Whether the mod including this should override the packaged game data.
+     * Setting this to true makes the mod basically the Delver version of an iWad in Doom. */
+    public boolean overrideBaseGame = false;
+
     public void merge(GameData modData) {
         tutorialLevel = modData.tutorialLevel;
         endingLevel = modData.endingLevel;

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/ModManager.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/ModManager.java
@@ -83,6 +83,17 @@ public class ModManager {
         findMods();
         filterMods();
         loadExcludesList();
+
+        // Find which path should be the base
+        String baseAssetPath = getBaseAssetPath();
+
+        // If the base path is just the prepackaged data, stop here
+        if(baseAssetPath.equals("."))
+            return;
+
+        // Make sure the new base path is only in once, at the beginning
+        modsFound.removeValue(baseAssetPath, false);
+        modsFound.set(0, baseAssetPath);
     }
 
     private String getBaseAssetPath() {
@@ -105,8 +116,8 @@ public class ModManager {
         // reset
         allMods.clear();
 
-        // add the default search path
-        allMods.add(getBaseAssetPath());
+        // add the baked in data path
+        allMods.add(".");
 
         FileHandle fh = Game.getInternal("mods");
         for(FileHandle h : fh.list()) {

--- a/jsonschema/current/dungeoneer/game/GameData.schema.json
+++ b/jsonschema/current/dungeoneer/game/GameData.schema.json
@@ -57,6 +57,11 @@
             "type": "boolean",
             "default": false,
             "description": "Is player allowed to jump."
+        },
+        "overrideBaseGame": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the mod including this should override the packaged game data."
         }
     },
     "required": [


### PR DESCRIPTION
Right now it is hard for a mod to be a complete total conversion of Delver, as the base game really wants to be used as the base for any mods added on top of it. This new field in the `game.dat` file lets a mod set itself as the base data instead, and have other mods merge on top of that.

* Changes the `data/game.dat` game definition file
    * Adds a new field, `overrideBaseGame` which defaults to false
    * When set to true in a mod, this mod will be used as the base game instead of the prepackaged data
    * Only one base game mod will win out, and that one is the last one found