### PR TITLE
Using English locale for parsing doubles

### DIFF
--- a/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/PropertiesMenu.java
+++ b/DelvEdit/src/com/interrupt/dungeoneer/editor/ui/PropertiesMenu.java
@@ -26,7 +26,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
+import java.util.Locale;
 
 public class PropertiesMenu extends Table {
     public ArrayMap<String, Array<Field>> arrayMap = new ArrayMap<String, Array<Field>>();
@@ -327,7 +329,7 @@ public class PropertiesMenu extends Table {
                         tf.addListener(new InputListener() {
                             @Override
                             public boolean keyDown(InputEvent event, int keycode) {
-                                DecimalFormat format = new DecimalFormat("##.##");
+                                DecimalFormat format = new DecimalFormat("##.##", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
                                 if(keycode == Input.Keys.UP) {
                                     double dval = 0;
                                     if(!tf.getText().equals("")) dval = Double.parseDouble(tf.getText());
@@ -350,7 +352,7 @@ public class PropertiesMenu extends Table {
 
                         // Allow drag on label to scrub value.
                         label.addListener(new InputListener() {
-                            private final DecimalFormat format = new DecimalFormat("##.##");
+                            private final DecimalFormat format = new DecimalFormat("##.##", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
                             private float firstX;
                             private float firstY;
                             private float lastX;


### PR DESCRIPTION
Fixes #285.

The issue was that `DecimalFormat` uses a locale that is probably dependent on the system.

So in English systems, the value is `0.7`, whereas in German the value is `0,7`.

When parsing the string as double that contains a comma, we get the exception.

Now, we explicitly set `.` to be the decimal format symbol.