### PR TITLE
Moving pathfinding behind an interface that can be set via game.dat

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/Monster.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/Monster.java
@@ -904,47 +904,13 @@ public class Monster extends Actor implements Directional {
 
 	private boolean findPathToPlayer(Level level)
 	{
-		PathNode node = Game.pathfinding.GetNodeAt(x + xa, y + ya, z + za);
+		Vector3 nextPathLocation = Game.instance.getPathfindingManager().getNextPathToTarget(level,this, Game.instance.player);
+        if(nextPathLocation == null)
+            return false;
 
-		if(node != null && node.playerSmell != Short.MAX_VALUE) {
-			PathNode picked = node;
-
-			Array<PathNode> adjacent = node.getConnections();
-			for(int i = 0; i < adjacent.size; i++) {
-				PathNode a = adjacent.get(i);
-				if(fleeing) {
-					if (a.playerSmell > picked.playerSmell) {
-						picked = a;
-					}
-				}
-				else {
-					if (a.playerSmell < picked.playerSmell) {
-						picked = a;
-					}
-				}
-			}
-
-			adjacent = node.getJumps();
-			for(int i = 0; i < adjacent.size; i++) {
-				PathNode a = adjacent.get(i);
-				if(fleeing) {
-					if (a.playerSmell > picked.playerSmell) {
-						picked = a;
-					}
-				}
-				else {
-					if (a.playerSmell < picked.playerSmell) {
-						picked = a;
-					}
-				}
-			}
-
-			targetx = picked.loc.x;
-			targety = picked.loc.y;
-			return true;
-		}
-
-		return false;
+        targetx = nextPathLocation.x;
+        targety = nextPathLocation.y;
+        return true;
 	}
 
 	@Override

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/PathNode.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/PathNode.java
@@ -2,7 +2,7 @@ package com.interrupt.dungeoneer.entities;
 
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
-import com.interrupt.dungeoneer.game.Pathfinding;
+import com.interrupt.dungeoneer.game.pathfinding.NodeGraphPathfinding;
 
 public class PathNode extends Entity {
     public transient short playerSmell = 0;
@@ -79,7 +79,7 @@ public class PathNode extends Entity {
             playerSmell = (short) Math.min(iteration, playerSmell);
         }
 
-        if(iteration++ < Pathfinding.MaxTraversal) {
+        if(iteration++ < NodeGraphPathfinding.MaxTraversal) {
             // normal connections
             for (int i = 0; i < connections.size; i++) {
                 PathNode node = connections.get(i);

--- a/Dungeoneer/src/com/interrupt/dungeoneer/entities/triggers/TriggeredElevator.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/entities/triggers/TriggeredElevator.java
@@ -12,6 +12,8 @@ import com.interrupt.dungeoneer.entities.PathNode;
 import com.interrupt.dungeoneer.entities.items.Weapon;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Level;
+import com.interrupt.dungeoneer.game.pathfinding.NodeGraphPathfinding;
+import com.interrupt.dungeoneer.game.pathfinding.PathfindingInterface;
 import com.interrupt.dungeoneer.gfx.WorldChunk;
 import com.interrupt.dungeoneer.tiles.Tile;
 
@@ -69,7 +71,7 @@ public class TriggeredElevator extends Trigger {
 	private transient Entity squishing = null;
 
 	private transient AmbientSound movingAmbientSound = null;
-	
+
 	@Override
 	public void doTriggerEvent(String value) {
 		if(state == ElevatorState.NONE) {
@@ -319,6 +321,9 @@ public class TriggeredElevator extends Trigger {
 		int minY = (int)Math.floor(y - collision.y);
 		int maxY = (int)Math.ceil(y + collision.y);
 
+        PathfindingInterface pathfinding = Game.instance.getPathfindingManager();
+        NodeGraphPathfinding nodeGraphPathfinding = (NodeGraphPathfinding)pathfinding;
+
 		for(int tileX = minX; tileX < maxX; tileX++) {
 			for (int tileY = minY; tileY < maxY; tileY++) {
 				markWorldAsDirty(tileX, tileY);
@@ -327,16 +332,19 @@ public class TriggeredElevator extends Trigger {
 				markWorldAsDirty(tileX, tileY + 1);
 				markWorldAsDirty(tileX, tileY - 1);
 
-				// Stop pathfinding to this tile if it has moved too much
+				// If we are using the node graph pathfinder, Stop pathfinding to this tile if it has moved too much
 				Tile t = level.getTileOrNull(tileX, tileY);
 				if(t == null)
 					continue;
 
-				PathNode n = Game.pathfinding.GetNodeAt(tileX + 0.5f, tileY + 0.5f, t.floorHeight);
-				if(n == null)
-					continue;
+                if(nodeGraphPathfinding == null)
+                    continue;
 
-				n.setEnabled(!t.blockMotion && Math.abs(amountFloorMovedSinceStart) < 0.5f);
+                PathNode n = nodeGraphPathfinding.GetNodeAt(tileX + 0.5f, tileY + 0.5f, t.floorHeight);
+                if (n == null)
+                    continue;
+
+                n.setEnabled(!t.blockMotion && Math.abs(amountFloorMovedSinceStart) < 0.5f);
 			}
 		}
 	}

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Game.java
@@ -10,7 +10,6 @@ import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.ArrayMap;
 import com.interrupt.dungeoneer.Audio;
 import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameInput;
@@ -26,8 +25,8 @@ import com.interrupt.dungeoneer.entities.triggers.TriggeredWarp;
 import com.interrupt.dungeoneer.game.Level.Source;
 import com.interrupt.dungeoneer.game.gamemode.delver.DelverGameMode;
 import com.interrupt.dungeoneer.game.gamemode.GameModeInterface;
-import com.interrupt.dungeoneer.game.gamemode.GameStateInterface;
-import com.interrupt.dungeoneer.generator.SectionDefinition;
+import com.interrupt.dungeoneer.game.pathfinding.NodeGraphPathfinding;
+import com.interrupt.dungeoneer.game.pathfinding.PathfindingInterface;
 import com.interrupt.dungeoneer.gfx.DecalManager;
 import com.interrupt.dungeoneer.gfx.animation.lerp3d.LerpedAnimationManager;
 import com.interrupt.dungeoneer.input.ControllerState;
@@ -44,7 +43,6 @@ import com.interrupt.utils.OSUtils;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.Comparator;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -122,7 +120,7 @@ public class Game {
 
     public static ExecutorService threadPool = Executors.newFixedThreadPool(4);
 
-    public static Pathfinding pathfinding = new Pathfinding();
+    protected PathfindingInterface pathfindingManager = new NodeGraphPathfinding();
 
     protected GameModeInterface gameMode = new DelverGameMode();
 
@@ -504,7 +502,7 @@ public class Game {
 
 		input.tick();
         Audio.tick(delta, player, level);
-		Game.pathfinding.tick(delta);
+		Game.instance.pathfindingManager.tick(delta);
 
         if(!gamepadManager.menuMode) {
 			gamepadManager.tick(delta);
@@ -1483,5 +1481,8 @@ public class Game {
 
     public GameModeInterface getGameMode() {
         return gameMode;
+    }
+    public PathfindingInterface getPathfindingManager() {
+        return pathfindingManager;
     }
 }

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/Level.java
@@ -21,6 +21,7 @@ import com.interrupt.dungeoneer.entities.Entity.EntityType;
 import com.interrupt.dungeoneer.entities.Stairs.StairDirection;
 import com.interrupt.dungeoneer.entities.triggers.ButtonDecal;
 import com.interrupt.dungeoneer.game.gamemode.GameModeInterface;
+import com.interrupt.dungeoneer.game.pathfinding.PathfindingInterface;
 import com.interrupt.dungeoneer.generator.DungeonGenerator;
 import com.interrupt.dungeoneer.generator.GenInfo;
 import com.interrupt.dungeoneer.generator.GenInfo.Markers;
@@ -1211,7 +1212,12 @@ public class Level {
 			spawnChaseEncounter();
 		}
 
-		Game.pathfinding.InitForLevel(this);
+        if(Game.instance == null)
+            return;
+
+        PathfindingInterface pathfinding = Game.instance.getPathfindingManager();
+        if(pathfinding != null)
+		    pathfinding.initForLevel(this);
 	}
 
 	public void initEntities(Array<Entity> entityList, Source source) {

--- a/Dungeoneer/src/com/interrupt/dungeoneer/game/pathfinding/PathfindingInterface.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/game/pathfinding/PathfindingInterface.java
@@ -1,0 +1,11 @@
+package com.interrupt.dungeoneer.game.pathfinding;
+
+import com.badlogic.gdx.math.Vector3;
+import com.interrupt.dungeoneer.entities.Entity;
+import com.interrupt.dungeoneer.game.Level;
+
+public interface PathfindingInterface {
+    void tick(float delta);
+    void initForLevel(Level level);
+    Vector3 getNextPathToTarget(Level level, Entity checking, Entity target);
+}

--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -35,6 +35,8 @@ import com.interrupt.dungeoneer.entities.triggers.TriggeredMessage;
 import com.interrupt.dungeoneer.entities.triggers.TriggeredMusic;
 import com.interrupt.dungeoneer.entities.triggers.TriggeredShop;
 import com.interrupt.dungeoneer.game.*;
+import com.interrupt.dungeoneer.game.pathfinding.NodeGraphPathfinding;
+import com.interrupt.dungeoneer.game.pathfinding.PathfindingInterface;
 import com.interrupt.dungeoneer.gfx.animation.lerp3d.LerpFrame;
 import com.interrupt.dungeoneer.gfx.animation.lerp3d.LerpedAnimation;
 import com.interrupt.dungeoneer.gfx.decals.DDecal;
@@ -3574,6 +3576,10 @@ public class GlRenderer {
 	Color pathfindingColorStart = new Color();
 	Color pathfindingColorEnd = new Color();
 	public void renderPathfinding() {
+        NodeGraphPathfinding pathfinding = (NodeGraphPathfinding)Game.instance.getPathfindingManager();
+        if(pathfinding == null)
+            return;
+
 		ShapeRenderer lineRenderer = collisionLineRenderer;
 		if(lineRenderer == null) lineRenderer = new ShapeRenderer();
 		lineRenderer.setProjectionMatrix(camera.combined);
@@ -3583,7 +3589,7 @@ public class GlRenderer {
 		lineRenderer.setColor(Color.WHITE);
 		lineRenderer.begin(ShapeType.Line);
 
-		for(PathNode node : Game.pathfinding.GetNodes()) {
+		for(PathNode node : pathfinding.GetNodes()) {
 			if(node != null) {
 				Array<PathNode> connections = node.getConnections();
 				Array<PathNode> jumps = node.getJumps();
@@ -3592,16 +3598,16 @@ public class GlRenderer {
 					PathNode c = connections.get(i);
 
 					float colorStart;
-					if(node.playerSmell > Pathfinding.MaxTraversal)
+					if(node.playerSmell > NodeGraphPathfinding.MaxTraversal)
 						colorStart = 0f;
 					else
-						colorStart = 1f - ((float)node.playerSmell / Pathfinding.MaxTraversal);
+						colorStart = 1f - ((float)node.playerSmell / NodeGraphPathfinding.MaxTraversal);
 
 					float colorEnd;
-					if(c.playerSmell > Pathfinding.MaxTraversal)
+					if(c.playerSmell > NodeGraphPathfinding.MaxTraversal)
 						colorEnd = 0f;
 					else
-						colorEnd = 1f - ((float)c.playerSmell / Pathfinding.MaxTraversal);
+						colorEnd = 1f - ((float)c.playerSmell / NodeGraphPathfinding.MaxTraversal);
 
 					pathfindingColorStart.set(colorStart, colorStart, colorStart, 1f);
 					pathfindingColorEnd.set(colorEnd, colorEnd, colorEnd, 1f);
@@ -3613,16 +3619,16 @@ public class GlRenderer {
 					PathNode c = jumps.get(i);
 
 					float colorStart;
-					if(node.playerSmell > Pathfinding.MaxTraversal)
+					if(node.playerSmell > NodeGraphPathfinding.MaxTraversal)
 						colorStart = 0f;
 					else
-						colorStart = 1f - ((float)node.playerSmell / Pathfinding.MaxTraversal);
+						colorStart = 1f - ((float)node.playerSmell / NodeGraphPathfinding.MaxTraversal);
 
 					float colorEnd;
-					if(c.playerSmell > Pathfinding.MaxTraversal)
+					if(c.playerSmell > NodeGraphPathfinding.MaxTraversal)
 						colorEnd = 0f;
 					else
-						colorEnd = 1f - ((float)c.playerSmell / Pathfinding.MaxTraversal);
+						colorEnd = 1f - ((float)c.playerSmell / NodeGraphPathfinding.MaxTraversal);
 
 					pathfindingColorStart.set(colorStart, colorStart * 0.1f, colorStart * 0.1f, 1f);
 					pathfindingColorEnd.set(colorEnd, colorEnd * 0.1f, colorEnd * 0.1f, 1f);


### PR DESCRIPTION
This also adds a new field in `game.dat` - `pathfindingManager`.

The new pathfinding interface itself is very small:
```
public interface PathfindingInterface {
    void tick(float delta);
    void initForLevel(Level level);
    Vector3 getNextPathToTarget(Level level, Entity checking, Entity target);
}
```