### PR TITLE
Fix 0 scale on text bug that crash the game

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -1977,7 +1977,7 @@ public class GlRenderer {
 
 	public void drawCenteredText(String text, float sPosY, float size, Color color, Color shadowColor)
 	{
-		if(text == null) return;
+		if(text == null || size == 0f) return;
 
 		font.getData().setScale(size * 0.14f);
         GlyphLayout bounds = FontBounds.GetBounds(font, text);


### PR DESCRIPTION
Hi, I've noticed that when the game window is scaled with a very small size the math used to resize text elements set their scale to 0.

Gdx seem to not allow that and crash the game.

I've found a bug on Windows (not sure if the same on other platforms) that happen when the game window is minimized, somewhat the game forget his window size and tries to scale, as said before, elements with 0 as a scale.

The change I've made was simply a check to stop rendering when the given scale for text is 0, seem to work.