### PR TITLE
Remove special casing of mobile tooltip ui

### DIFF
--- a/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/Dungeoneer/src/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -747,14 +747,10 @@ public class GlRenderer {
 				Integer uiTouchPointer = game.input.uiTouchPointer;
 				if(uiTouchPointer == null) uiTouchPointer = 0;
 
-				if(Game.isMobile) {
-					this.drawTextOnScreen(hoverItm.GetInfoText(), Gdx.input.getX(uiTouchPointer) - Gdx.graphics.getWidth() / 2 + uiSize * 1.25f, -Gdx.input.getY(uiTouchPointer) + Gdx.graphics.getHeight() / 2, uiSize / 5, Color.WHITE, Color.BLACK);
-				} else {
-                    int tooltipX = game.input.getPointerX(uiTouchPointer);
-                    int tooltipY = game.input.getPointerY(uiTouchPointer);
+                int tooltipX = game.input.getPointerX(uiTouchPointer);
+                int tooltipY = game.input.getPointerY(uiTouchPointer);
 
-                    Game.tooltip.show(tooltipX, -tooltipY + Gdx.graphics.getHeight(), hoverItm);
-				}
+                Game.tooltip.show(tooltipX, -tooltipY + Gdx.graphics.getHeight(), hoverItm);
 
 				uiBatch.end();
 			}


### PR DESCRIPTION
## Summary
When phone screens were tiny and screen real estate was precious we special cased item tool tips to be non-intrusive. Now they just look broken and are hard to read. This change removes the special casing and allows the item tooltips to render the same on mobile and desktop.