### PR TITLE
Fixes door drawable not updating when changing texure

### DIFF
--- a/core/src/main/java/com/interrupt/dungeoneer/entities/Door.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/entities/Door.java
@@ -140,6 +140,7 @@ public class Door extends Entity {
 	private transient float rotateAnimSolidPoint = 0.8f;
 
     public transient String lastMeshFile = null;
+    public transient String lastTextureFile = null;
 
 	public Vector3 dir = new Vector3(Vector3.Z);
 
@@ -504,10 +505,11 @@ public class Door extends Entity {
 	public void updateDrawable() {
 		// init the drawable
 		DrawableMesh doorDrawable = null;
-		if(!(drawable instanceof DrawableMesh) || (lastMeshFile != null && !lastMeshFile.equals(doorMesh))) {
+		if(!(drawable instanceof DrawableMesh) || (lastMeshFile != null && !lastMeshFile.equals(doorMesh)) || (lastTextureFile != null && !lastTextureFile.equals(doorTexture))) {
 			doorDrawable = new DrawableMesh(doorMesh, doorTexture);
 			drawable = doorDrawable;
             lastMeshFile = doorMesh;
+			lastTextureFile = doorTexture;
 		}
 
 		if(drawable != null) {


### PR DESCRIPTION
Fixes #306.

### Summary
Adds a transient `lastTextureFile` property and checks whether we have changed the texture AND the mesh in order to update the drawable.