### PR TITLE
Fixes/238 treasure hunter achievement

### DIFF
--- a/core/src/main/java/com/interrupt/dungeoneer/entities/Player.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/entities/Player.java
@@ -1,7 +1,6 @@
 package com.interrupt.dungeoneer.entities;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Interpolation;
@@ -11,7 +10,6 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.math.collision.Ray;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.IntArray;
 import com.interrupt.api.steam.SteamApi;
 import com.interrupt.dungeoneer.Audio;
 import com.interrupt.dungeoneer.GameInput;
@@ -21,10 +19,8 @@ import com.interrupt.dungeoneer.collision.Collision;
 import com.interrupt.dungeoneer.entities.items.*;
 import com.interrupt.dungeoneer.entities.items.Potion.PotionType;
 import com.interrupt.dungeoneer.entities.items.Weapon.DamageType;
-import com.interrupt.dungeoneer.entities.projectiles.BeamProjectile;
 import com.interrupt.dungeoneer.entities.triggers.ButtonModel;
 import com.interrupt.dungeoneer.entities.triggers.Trigger;
-import com.interrupt.dungeoneer.entities.triggers.Trigger.TriggerType;
 import com.interrupt.dungeoneer.game.*;
 import com.interrupt.dungeoneer.gfx.GlRenderer;
 import com.interrupt.dungeoneer.gfx.animation.lerp3d.LerpFrame;
@@ -40,7 +36,6 @@ import com.interrupt.dungeoneer.statuseffects.*;
 import com.interrupt.dungeoneer.tiles.ExitTile;
 import com.interrupt.dungeoneer.tiles.Tile;
 import com.interrupt.helpers.PlayerHistory;
-import com.interrupt.managers.HUDManager;
 import com.interrupt.managers.StringManager;
 
 import java.text.MessageFormat;
@@ -2338,4 +2333,9 @@ public class Player extends Actor {
 				itm.drawable.refresh();
 		}
     }
+
+	public void addGold(int amount) {
+		gold += amount;
+		history.tookGold(amount);
+	}
 }

--- a/core/src/main/java/com/interrupt/dungeoneer/entities/items/Gold.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/entities/items/Gold.java
@@ -1,6 +1,5 @@
 package com.interrupt.dungeoneer.entities.items;
 
-import com.badlogic.gdx.math.Vector3;
 import com.interrupt.dungeoneer.Audio;
 import com.interrupt.dungeoneer.annotations.EditorProperty;
 import com.interrupt.dungeoneer.entities.Item;
@@ -58,7 +57,7 @@ public class Gold extends Item {
 		if(isActive && autoPickup) {
 			Player p = Game.instance.player;
 			if(Math.abs(p.x + 0.5f - x) < 0.3f && Math.abs(p.y + 0.5f - y ) < 0.3f) {
-				p.gold++;
+				p.addGold(1);;
 				isActive = false;
 			}
 		}
@@ -66,7 +65,7 @@ public class Gold extends Item {
 	
 	protected void pickup(Player player) {
 		if(isActive) {
-			player.gold += goldAmount;
+			player.addGold(goldAmount);
 			isActive = false;
 			Audio.playSound(pickupSound, 0.3f, 1f);
 			makeItemPickupAnimation(player);

--- a/core/src/main/java/com/interrupt/dungeoneer/game/Progression.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/game/Progression.java
@@ -1,9 +1,7 @@
 package com.interrupt.dungeoneer.game;
 
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ArrayMap;
-import com.interrupt.api.steam.workshop.WorkshopModData;
 import com.interrupt.dungeoneer.entities.Item;
 
 import java.util.HashMap;
@@ -14,8 +12,6 @@ public class Progression {
 	public int experienceGained = 0;
 	public int messagesFound = 0;
 	public boolean won = false;
-
-	public int goldAtStartOfRun = 0;
 
     public int wins = 0;
     public int deaths = 0;
@@ -47,7 +43,6 @@ public class Progression {
 		dungeonAreasSeen.clear();
 		uniqueItemsSpawned.clear();
 		untilDeathProgressionTriggers.clear();
-		goldAtStartOfRun = gold;
 	}
 
 	public void trackMods() {

--- a/core/src/main/java/com/interrupt/dungeoneer/screens/GameOverScreen.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/screens/GameOverScreen.java
@@ -3,13 +3,11 @@ package com.interrupt.dungeoneer.screens;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.math.Interpolation;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.actions.Actions;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Label.LabelStyle;
-import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Timer;
@@ -302,11 +300,6 @@ public class GameOverScreen extends StatsScreen {
         }
         else {
             SteamApi.api.achieve("WON");
-        }
-
-        int goldThisRun = Game.instance.player.gold - Game.instance.progression.goldAtStartOfRun;
-        if(goldThisRun >= 300) {
-            SteamApi.api.achieve("RUN_GOLD");
         }
     }
 

--- a/core/src/main/java/com/interrupt/dungeoneer/screens/StatsScreen.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/screens/StatsScreen.java
@@ -24,11 +24,9 @@ public class StatsScreen extends BaseScreen {
 		Table mainTable = new Table();
 		mainTable.setFillParent(true);
 
-		int goldThisRun = Math.max(0, Game.instance.player.gold - Game.instance.progression.goldAtStartOfRun);
-		
 		Table innerTable = new Table();
 		if(progress > 0) makeStat(innerTable, StringManager.get("screens.GameOverScreen.playtimeStatLabel"), Game.instance.player.getPlaytime(), doFade);
-		if(progress > 1) makeStat(innerTable, StringManager.get("screens.GameOverScreen.goldStatLabel"), goldThisRun, doFade);
+		if(progress > 1) makeStat(innerTable, StringManager.get("screens.GameOverScreen.goldStatLabel"), Game.instance.player.history.goldTaken, doFade);
 		if(progress > 2) makeStat(innerTable, StringManager.get("screens.GameOverScreen.killsStatLabel"), Game.instance.player.history.monstersKilled, doFade);
 		if(progress > 3) makeStat(innerTable, StringManager.get("screens.GameOverScreen.damageStatLabel"), Game.instance.player.history.damageTaken, doFade);
 		if(progress > 4) makeStat(innerTable, StringManager.get("screens.GameOverScreen.potionsStatLabel"), Game.instance.player.history.potionsDrank, doFade);

--- a/core/src/main/java/com/interrupt/dungeoneer/screens/WinScreen.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/screens/WinScreen.java
@@ -190,12 +190,6 @@ public class WinScreen extends StatsScreen {
 
     private void showStats() {
         SteamApi.api.achieve("WON");
-
-        int goldThisRun = Game.instance.player.gold - Game.instance.progression.goldAtStartOfRun;
-        if(goldThisRun >= 300) {
-            SteamApi.api.achieve("RUN_GOLD");
-        }
-
         showingStats = true;
         showStats(1);
     }

--- a/core/src/main/java/com/interrupt/helpers/PlayerHistory.java
+++ b/core/src/main/java/com/interrupt/helpers/PlayerHistory.java
@@ -20,6 +20,7 @@ public class PlayerHistory {
 	public int timesPoisoned = 0;
 	public int thingsIdentified = 0;
 	public int secretsFound = 0;
+	public int goldTaken = 0;
 	
 	public PlayerHistory() { }
 	
@@ -122,6 +123,15 @@ public class PlayerHistory {
 
 		if(secretsFound >= 5) {
 			SteamApi.api.achieve("RUN_SECRETS");
+		}
+	}
+
+	public void tookGold(int amount) {
+		Gdx.app.log("PlayerHistory", "Took gold");
+		goldTaken += amount;
+
+		if(goldTaken >= 300) {
+			SteamApi.api.achieve("RUN_GOLD");
 		}
 	}
 }


### PR DESCRIPTION
Fixes #238.

### Summary
- The "Treasure Hunter" achievement is now immediately being dealt when a player collects 300 gold or more in a single run
- The stats screen can no longer show negative amount of gold collected (ignores gold spent)
- When quitting a game from the pause menu, we now properly store gold in the progression and therefore it is correctly displayed on the save slot

⚠️ Players have to be aware that, because of how gold is now tracked in the player history - and we don't migrate `goldAtStartOfRun` to the player history, the achievement can only be granted with a ~~NEW SAVE~~ NEW RUN.

### Testing
- Start a new game
- Collect 300 gold or more in one run
- See that the achievement gets dealt