### PR TITLE
Fix Mobile UI Buttons Turning Black

### DIFF
--- a/core/src/main/java/com/interrupt/dungeoneer/screens/LevelChangeScreen.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/screens/LevelChangeScreen.java
@@ -47,6 +47,7 @@ public class LevelChangeScreen extends BaseScreen {
 			GameManager.renderer.disposeMeshes();
 			Art.KillCache();
 			GameManager.renderer.initTextures();
+            GameManager.renderer.initHud();
 		}
 	}
 


### PR DESCRIPTION
## Summary
When going down a level the mobile ui buttons turn black. This is a result of the levelchange screen killing the art cache. The fix is to init the hud after the textures have been init'd.

Fixes #334 