### PR TITLE
Add debug button to pause menu

### DIFF
--- a/android/src/main/java/com/interrupt/dungeoneer/android/DungeoneerAndroidActivity.java
+++ b/android/src/main/java/com/interrupt/dungeoneer/android/DungeoneerAndroidActivity.java
@@ -1,9 +1,11 @@
 package com.interrupt.dungeoneer.android;
 
+import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import com.badlogic.gdx.backends.android.AndroidApplication;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
 import com.interrupt.dungeoneer.GameApplication;
+import com.interrupt.dungeoneer.game.Game;
 
 public class DungeoneerAndroidActivity extends AndroidApplication {
     /** Called when the activity is first created. */
@@ -12,6 +14,10 @@ public class DungeoneerAndroidActivity extends AndroidApplication {
         super.onCreate(savedInstanceState);
         AndroidApplicationConfiguration configuration = new AndroidApplicationConfiguration();
         configuration.useImmersiveMode = true; // Recommended, but not required.
+
+        // Enable debug mode for debug builds
+        Game.isDebugMode = (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+
         initialize(new GameApplication(), configuration);
     }
 }

--- a/core/src/main/java/com/interrupt/dungeoneer/overlays/PauseOverlay.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/overlays/PauseOverlay.java
@@ -1,8 +1,10 @@
 package com.interrupt.dungeoneer.overlays;
 
 import com.badlogic.gdx.Input.Keys;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
+import com.badlogic.gdx.scenes.scene2d.ui.Cell;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Label.LabelStyle;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
@@ -76,8 +78,20 @@ public class PauseOverlay extends WindowOverlay {
 			}
 		});
 
-		TextButton controlsBtn = new TextButton(" " + StringManager.get("overlays.PauseOverlay.quitButton") + " ", skin.get(TextButtonStyle.class));
-		controlsBtn.addListener(new ClickListener() {
+        TextButton debugBtn = null;
+        if (Game.isDebugMode) {
+            debugBtn = new TextButton("Debug", skin.get(TextButtonStyle.class));
+            debugBtn.addListener(new ClickListener() {
+                @Override
+                public void clicked(InputEvent event, float x, float y) {
+                    OverlayManager.instance.remove(thisOverlay);
+                    OverlayManager.instance.push(new DebugOverlay(Game.instance.player));
+                }
+            });
+        }
+
+		TextButton quitBtn = new TextButton(" " + StringManager.get("overlays.PauseOverlay.quitButton") + " ", skin.get(TextButtonStyle.class));
+		quitBtn.addListener(new ClickListener() {
 			@Override
 			public void clicked(InputEvent event, float x, float y) {
 				OverlayManager.instance.clear();
@@ -94,12 +108,24 @@ public class PauseOverlay extends WindowOverlay {
 	    contentTable.row();
 		contentTable.add(optionsBtn).padBottom(1f).fillX();
 	    contentTable.row();
-	    contentTable.add(controlsBtn).fillX();
+	    Cell<Actor> l = contentTable.add(quitBtn);
+        l.fillX();
+
+        if (debugBtn != null) {
+            l.padBottom(8f);
+            contentTable.row();
+            contentTable.add(debugBtn).padTop(1f).fillX();
+        }
+
 
 	    buttonOrder.clear();
 	    buttonOrder.add(backBtn);
 	    buttonOrder.add(optionsBtn);
-	    buttonOrder.add(controlsBtn);
+	    buttonOrder.add(quitBtn);
+
+        if (debugBtn != null) {
+            buttonOrder.add(debugBtn);
+        }
 
 		return contentTable;
 	}


### PR DESCRIPTION
<img width="1321" height="925" alt="Screenshot 2025-10-21 at 9 55 57 PM" src="https://github.com/user-attachments/assets/74625c34-6342-45ba-bfb7-046c6af8516c" />


## Summary
Adds debug button to pause menu. This enables us to more easily grab screenshots for mobile stores by cheating. :)

Note this only is shown when `Game.debugMode` is true. The android launcher was also updated to set this flag to true if running on a debug build.