### PR TITLE
Hide Non-Applicable Options on Mobile

### DIFF
--- a/assets/data/strings.dat
+++ b/assets/data/strings.dat
@@ -320,6 +320,11 @@
         "localizedName": "Look Y",
         "comment": "Label for the mouse y-axis sensitivity slider."
     },
+    "screens.OptionsScreen.lookSpeedLabel": {
+            "class": "com.interrupt.dungeoneer.game.LocalizedString",
+            "localizedName": "Look Speed",
+            "comment": "Label for the look speed slider."
+        },
     "screens.OptionsScreen.invertLookLabel": {
         "class": "com.interrupt.dungeoneer.game.LocalizedString",
         "localizedName": "Invert Look",

--- a/core/src/main/java/com/interrupt/dungeoneer/Audio.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/Audio.java
@@ -80,7 +80,7 @@ public class Audio {
 	}
 
     static public int maxSoundsPerPlatform() {
-        if (Game.isMobile) {
+        if (GameApplication.isMobile()) {
             return 1;
         }
 

--- a/core/src/main/java/com/interrupt/dungeoneer/GameApplication.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/GameApplication.java
@@ -159,4 +159,11 @@ public class GameApplication extends Game {
         if(newLevelChangeScreen != null)
             instance.levelChangeScreen = newLevelChangeScreen;
     }
+
+    public static boolean isMobile() {
+         if (Gdx.app.getType() == Application.ApplicationType.Android) return true;
+         if (Gdx.app.getType() == Application.ApplicationType.iOS) return true;
+
+         return false;
+    }
 }

--- a/core/src/main/java/com/interrupt/dungeoneer/GameInput.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/GameInput.java
@@ -309,7 +309,7 @@ public class GameInput implements InputProcessor {
 	public boolean isActionRequested(Action action){
 		boolean isActionRequested = checkKeyDown(action);
 
-        if (Gdx.app.getType() == Application.ApplicationType.Desktop && !Game.isMobile) {
+        if (Gdx.app.getType() == Application.ApplicationType.Desktop && !GameApplication.isMobile()) {
 		    //Only trap caughtCursor for the primary button
             isActionRequested |= (caughtCursor && (Options.instance.mouseButton1Action == action) && isPressedMouse1);
             isActionRequested |= ((Options.instance.mouseButton2Action == action) && isPressedMouse2);

--- a/core/src/main/java/com/interrupt/dungeoneer/GameManager.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/GameManager.java
@@ -87,7 +87,7 @@ public class GameManager {
 			GameManager.renderer.clearLights();
 
 			if (game != null && game.player != null && !game.player.isDead) {
-				if (Game.isMobile && Gdx.input.isKeyPressed(Input.Keys.BACK)) {
+				if (GameApplication.isMobile() && Gdx.input.isKeyPressed(Input.Keys.BACK)) {
 					OverlayManager.instance.push(new PauseOverlay());
 				} else if (Gdx.input.isKeyPressed(Input.Keys.ESCAPE) || this.myGameApp.input.gamepadManager.controllerState.buttonEvents.contains(Actions.Action.PAUSE, true)) {
 

--- a/core/src/main/java/com/interrupt/dungeoneer/entities/Monster.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/entities/Monster.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.interrupt.dungeoneer.Audio;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.annotations.EditorProperty;
 import com.interrupt.dungeoneer.entities.Door.DoorState;
@@ -1238,7 +1239,7 @@ public class Monster extends Actor implements Directional {
 			Actor t = (Actor) target;
 			int dealt = t.damageRoll(atk + level, damageType, this);
 
-			if (!Game.isMobile && target instanceof Player)
+			if (!GameApplication.isMobile() && target instanceof Player)
 				Game.flash(Colors.HURT_FLASH, 20);
 
 			if (dealt > 0) {

--- a/core/src/main/java/com/interrupt/dungeoneer/entities/Player.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/entities/Player.java
@@ -12,6 +12,7 @@ import com.badlogic.gdx.math.collision.Ray;
 import com.badlogic.gdx.utils.Array;
 import com.interrupt.api.steam.SteamApi;
 import com.interrupt.dungeoneer.Audio;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameInput;
 import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.collision.Collidor;
@@ -858,7 +859,7 @@ public class Player extends Actor {
 		else if(heldItem == null) handAnimation = null;
 
 		// Check for mobile attack press
-		if(Game.isMobile && !isInOverlay)
+		if(GameApplication.isMobile() && !isInOverlay)
 		{
 			attack = input.isAttackPressed() || Game.hud.isAttackPressed() || controllerState.attack;
             drop = input.isDropPressed() || Game.hud.isThrowPressed() || controllerState.drop;
@@ -960,7 +961,7 @@ public class Player extends Actor {
 
         // Only allow picking up items from the world if the inventory is showing
         boolean shouldPickupItem = (!input.isCursorCatched() || input.showingGamepadCursor) &&
-            !Game.isMobile &&
+            !GameApplication.isMobile() &&
             Game.instance.input.isPointerTouched(0);
 
 		if(!inOverlay && !isDead && shouldPickupItem) {
@@ -993,14 +994,14 @@ public class Player extends Actor {
 		}
 
 		hovering = null;
-		if(!touchingItem && !Game.isMobile && (!input.isCursorCatched() || input.showingGamepadCursor)) {
+		if(!touchingItem && !GameApplication.isMobile() && (!input.isCursorCatched() || input.showingGamepadCursor)) {
 			hovering = pickItem(level, input.getPointerX(), input.getPointerY(), 0.9f);
 		}
 
         boolean showUseMessages = canShowUseMessages(input);
 		if(showUseMessages) {
 			String useText = ReadableKeys.keyNames.get(Actions.keyBindings.get(Action.USE));
-			if(Game.isMobile) useText = StringManager.get("entities.Player.mobileUseText");
+			if(GameApplication.isMobile()) useText = StringManager.get("entities.Player.mobileUseText");
 
 			Entity centered = pickEntity(level, Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2, 0.7f);
 			if(centered != null && centered != this) {
@@ -1067,7 +1068,7 @@ public class Player extends Actor {
 		}
 
 		// touch movement
-		if(Game.isMobile && !isDead && !isInOverlay) {
+		if(GameApplication.isMobile() && !isDead && !isInOverlay) {
 			float max = 60;
 
 			if(input.isLeftTouched() && !(touchingItem && input.uiTouchPointer == input.leftPointer) && Game.dragging == null) {
@@ -2092,7 +2093,7 @@ public class Player extends Actor {
 	}
 
 	public void updateMouseInput(GameInput input) {
-		/*if(!touchingItem && !Game.isMobile)
+		/*if(!touchingItem && !GameApplication.isMobile())
 		{
 			if(input.caughtCursor) {
 				rot -= (((float)Gdx.input.getDeltaX()) / 230.0) * Options.instance.mouseXSensitivity;
@@ -2285,7 +2286,7 @@ public class Player extends Actor {
 			return;
 		}
 
-		if(!touchingItem && !Game.isMobile )
+		if(!touchingItem && !GameApplication.isMobile() )
 		{
 			if(caughtCursor) {
 				rot -= deltaX * 0.003 * Options.instance.mouseXSensitivity;

--- a/core/src/main/java/com/interrupt/dungeoneer/entities/Stairs.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/entities/Stairs.java
@@ -1,6 +1,7 @@
 package com.interrupt.dungeoneer.entities;
 
 import com.badlogic.gdx.graphics.Color;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.annotations.EditorProperty;
 import com.interrupt.dungeoneer.game.Game;
@@ -16,15 +17,15 @@ import java.text.MessageFormat;
 
 public class Stairs extends Entity {
 	public enum StairDirection { up, down };
-	
+
 	@EditorProperty
 	public StairDirection direction;
-	
+
 	public Stairs() { artType = ArtType.sprite; }
-	
+
 	@EditorProperty
 	public float exitRotation = 0;
-	
+
 	private transient boolean didInit = false;
 
 	public Material tileMaterial = new Material("t1", (byte)8);
@@ -37,7 +38,7 @@ public class Stairs extends Entity {
 		isSolid = false;
 		collision.set(0.3f,0.3f,0.2f);
 	}
-	
+
 	public Stairs(float x, float y, int tex, StairDirection direction) {
 		super(x, y, tex, false);
 		this.direction = direction;
@@ -45,7 +46,7 @@ public class Stairs extends Entity {
 		isSolid = false;
 		collision.set(0.3f,0.3f,0.2f);
 	}
-	
+
 	@Override
 	public void tick(Level level, float delta)
 	{
@@ -57,25 +58,25 @@ public class Stairs extends Entity {
 			didInit = true;
 		}
 	}
-	
+
 	public void encroached(Player player)
 	{
 		if(player.ignoreStairs || Game.messageTimer > 1) return;
-		
-		if(Game.isMobile)
+
+		if(GameApplication.isMobile())
 			Game.ShowMessage(MessageFormat.format(StringManager.get("entities.Stairs.mobileUseText"), direction.toString().toUpperCase()), 0.5f, 1f);
 	}
-	
+
 	public void use(Player player, float projx, float projy)
-	{	
+	{
 		float pxdir = player.x - x;
 		float pydir = player.y - y;
 		float playerdist = GlRenderer.FastSqrt(pxdir * pxdir + pydir * pydir);
-		
+
 		if(playerdist > 1.1) return;
-		
+
 		changeLevel(Game.GetLevel());
-		
+
 		Game.ShowMessage("", 1);
 	}
 
@@ -87,7 +88,7 @@ public class Stairs extends Entity {
 	{
 		GameManager.getGame().changeLevel(this);
 	}
-	
+
 	@Override
 	public void rotate90() {
 		if(direction == StairDirection.up)
@@ -95,20 +96,20 @@ public class Stairs extends Entity {
 		else
 			exitRotation += 90;
 	}
-	
+
 	@Override
 	public void init(Level level, Source source) {
 		super.init(level, source);
-		
+
 		if(direction == StairDirection.down) level.down = this;
 		else if(direction == StairDirection.up) level.up = this;
 	}
-	
+
 	@Override
 	public void updateLight(Level level) {
 		color = level.getLightColorAt(x, y, z + 0.08f, null, new Color());
 	}
-	
+
 	@Override
 	public void onTrigger(Entity instigator, String value) {
 		changeLevel(Game.GetLevel());

--- a/core/src/main/java/com/interrupt/dungeoneer/game/Game.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/game/Game.java
@@ -83,7 +83,6 @@ public class Game {
 	public EntityManager entityManager;
     public static HUDManager hudManager;
 
-	public static boolean isMobile = false;
 	public static boolean isDebugMode = false;
 	public static boolean drawDebugBoxes = false;
 	public static boolean ignoreEscape = false;
@@ -215,7 +214,6 @@ public class Game {
         gameMode.loadGameState(saveLoc);
 
         // init some of the UI
-		isMobile = false;
 		Gdx.input.setCursorCatched(true);
 		hud = new Hud();
 
@@ -255,7 +253,7 @@ public class Game {
 
 		if(message.size > 0) messageTimer = 400;
 
-		if(!isMobile)
+		if(!GameApplication.isMobile())
 			GameApplication.instance.input.caughtCursor = true;
 
 		GameScreen.resetDelta = true;
@@ -378,9 +376,7 @@ public class Game {
 
 		boolean didLoad = load();
 
-		isMobile = Gdx.app.getType() == ApplicationType.Android || Gdx.app.getType() == ApplicationType.iOS;
-
-		if(!isMobile) {
+		if(!GameApplication.isMobile()) {
 			Gdx.input.setCursorCatched(true);
 			hud = new Hud();
 		} else {
@@ -455,8 +451,9 @@ public class Game {
 
 		if(message.size > 0) messageTimer = 400;
 
-		if(!isMobile)
-			GameApplication.instance.input.caughtCursor = true;
+		if(!GameApplication.isMobile()) {
+            GameApplication.instance.input.caughtCursor = true;
+        }
 
 		GameScreen.resetDelta = true;
 	}
@@ -1086,7 +1083,7 @@ public class Game {
             }
         }
 
-        if (OSUtils.isMobile() && Gdx.files != null) {
+        if (GameApplication.isMobile() && Gdx.files != null) {
             if (Gdx.files.isExternalStorageAvailable()) {
                 return Gdx.files.external("Delver/" + file);
             }
@@ -1129,7 +1126,7 @@ public class Game {
 	public static float GetInventoryUiSize()
 	{
 		float uiSize = GetUiSize();
-        if(!isMobile)
+        if(!GameApplication.isMobile())
             return uiSize;
 
         // Scale the inventory size up more for mobile
@@ -1339,7 +1336,7 @@ public class Game {
 
 		// Refresh the UI
 		Game.RefreshUI();
-		if(input != null && !Game.isMobile) input.setCursorCatched(menuMode == MenuMode.Hidden);
+		if(input != null && !GameApplication.isMobile()) input.setCursorCatched(menuMode == MenuMode.Hidden);
 
 		// Hide the map!
 		if(Game.instance.getShowingMenu()) {
@@ -1506,7 +1503,7 @@ public class Game {
 		min = (min / 10f);
 
 		// Increase the base UI scale for Mobile devices
-		if(isMobile) {
+		if(GameApplication.isMobile()) {
 			min *= 1.2f;
 		}
 

--- a/core/src/main/java/com/interrupt/dungeoneer/gfx/GlRenderer.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/gfx/GlRenderer.java
@@ -731,7 +731,7 @@ public class GlRenderer {
             }
 
             boolean usingGamepadCursor = game.input.getGamepadCursorPosition() != null;
-			if(Game.isMobile || usingGamepadCursor) {
+			if(GameApplication.isMobile() || usingGamepadCursor) {
                 InventoryItemButton draggingButton = Hud.getItemBeingDragged();
                 if(draggingButton != null) {
                     hoverItm = draggingButton.getItem();
@@ -1720,7 +1720,7 @@ public class GlRenderer {
 			// pick a color for this box
 			uiBatch.enableBlending();
 
-			if((Game.isMobile || !game.input.caughtCursor) && equipLoc.isHovered())
+			if((GameApplication.isMobile() || !game.input.caughtCursor) && equipLoc.isHovered())
 				if(Game.dragging != null && Game.dragging.GetEquipLoc().equals(equipLoc.equipLoc))
 					uiBatch.setColor(INVBOX_CAN_EQUIP_HOVER);
 				else
@@ -1793,7 +1793,7 @@ public class GlRenderer {
 					uiBatch.setColor(INVBOXSELECTED);
 				else if(at != null && game.player.equipped(at))
 					uiBatch.setColor(INVBOXEQUIPPED);
-				else if((Game.isMobile || !game.input.caughtCursor) && hotbar.getMouseOverSlot() != null && hotbar.getMouseOverSlot() == i)
+				else if((GameApplication.isMobile() || !game.input.caughtCursor) && hotbar.getMouseOverSlot() != null && hotbar.getMouseOverSlot() == i)
 					uiBatch.setColor(INVBOXHOVER);
 				else
 					uiBatch.setColor(INVBOX);

--- a/core/src/main/java/com/interrupt/dungeoneer/overlays/MapOverlay.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/overlays/MapOverlay.java
@@ -16,6 +16,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.viewport.FillViewport;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.entities.Entity;
 import com.interrupt.dungeoneer.game.Game;
@@ -116,7 +117,7 @@ public class MapOverlay extends Overlay {
 
             @Override
             public boolean touchUp(int i, int i2, int i3, int i4) {
-                if(Game.isMobile)
+                if(GameApplication.isMobile())
                     OverlayManager.instance.pop();
 
                 return false;

--- a/core/src/main/java/com/interrupt/dungeoneer/overlays/OptionsInputOverlay.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/overlays/OptionsInputOverlay.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Align;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Options;
 import com.interrupt.dungeoneer.ui.ActionSpinnerButton;
@@ -57,16 +58,20 @@ public class OptionsInputOverlay extends WindowOverlay {
             }
         });
 
-        TextButton keysBtn = new TextButton(StringManager.get("screens.OptionsInputScreen.keysButton"), skin.get(TextButton.TextButtonStyle.class));
-        keysBtn.setWidth(200);
-        keysBtn.setHeight(50);
-        keysBtn.addListener(new ClickListener() {
-            @Override
-            public void clicked(InputEvent event, float x, float y) {
-                saveOptions();
-                OverlayManager.instance.replaceCurrent(new OptionsKeysOverlay(dimScreen, showBackground));
-            }
-        });
+        TextButton keysBtn = null;
+
+        if (!GameApplication.isMobile()) {
+            keysBtn = new TextButton(StringManager.get("screens.OptionsInputScreen.keysButton"), skin.get(TextButton.TextButtonStyle.class));
+            keysBtn.setWidth(200);
+            keysBtn.setHeight(50);
+            keysBtn.addListener(new ClickListener() {
+                @Override
+                public void clicked(InputEvent event, float x, float y) {
+                    saveOptions();
+                    OverlayManager.instance.replaceCurrent(new OptionsKeysOverlay(dimScreen, showBackground));
+                }
+            });
+        }
 
         TextButton gamepadBtn = null;
         if (Game.gamepadManager.controllerCount() > 0) {
@@ -119,75 +124,84 @@ public class OptionsInputOverlay extends WindowOverlay {
 
         addGamepadButtonOrder(sliderLookY, lookYLabel);
 
-        // Invert Look
-
-        Label invertLookLabel = new Label(StringManager.get("screens.OptionsScreen.invertLookLabel"), skin.get(Label.LabelStyle.class));
-        mainTable.add(invertLookLabel);
-
-        invertLook = new CheckBox("", skin.get(CheckBox.CheckBoxStyle.class));
-        invertLook.setChecked((options.mouseInvert));
-
-        mainTable.add(invertLook);
-        mainTable.row();
-
-        addGamepadButtonOrder(invertLook, invertLookLabel);
-
         // Mouse Buttons
+        if (!GameApplication.isMobile()) {
+            // Invert Look
 
-        spinnerMouseButton1 = new ActionSpinnerButton(Options.instance.mouseButton1Action,skin.get(TextButton.TextButtonStyle.class));
+            Label invertLookLabel = new Label(StringManager.get("screens.OptionsScreen.invertLookLabel"), skin.get(Label.LabelStyle.class));
+            mainTable.add(invertLookLabel);
 
-        Label mouseButton1Label = new Label(StringManager.get("screens.OptionsScreen.mouseButton1Label"), skin.get(Label.LabelStyle.class));
-        mainTable.add(mouseButton1Label);
-        mainTable.add(spinnerMouseButton1);
-        mainTable.row();
+            invertLook = new CheckBox("", skin.get(CheckBox.CheckBoxStyle.class));
+            invertLook.setChecked((options.mouseInvert));
 
-        addGamepadButtonOrder(spinnerMouseButton1, mouseButton1Label);
+            mainTable.add(invertLook);
+            mainTable.row();
 
-        spinnerMouseButton2 = new ActionSpinnerButton(Options.instance.mouseButton2Action,skin.get(TextButton.TextButtonStyle.class));
+            addGamepadButtonOrder(invertLook, invertLookLabel);
 
-        Label mouseButton2Label = new Label(StringManager.get("screens.OptionsScreen.mouseButton2Label"), skin.get(Label.LabelStyle.class));
-        mainTable.add(mouseButton2Label);
-        mainTable.add(spinnerMouseButton2);
-        mainTable.row();
+            spinnerMouseButton1 = new ActionSpinnerButton(Options.instance.mouseButton1Action, skin.get(TextButton.TextButtonStyle.class));
 
-        addGamepadButtonOrder(spinnerMouseButton2, mouseButton2Label);
+            Label mouseButton1Label = new Label(StringManager.get("screens.OptionsScreen.mouseButton1Label"), skin.get(Label.LabelStyle.class));
+            mainTable.add(mouseButton1Label);
+            mainTable.add(spinnerMouseButton1);
+            mainTable.row();
 
-        spinnerMouseButton3 = new ActionSpinnerButton(Options.instance.mouseButton3Action,skin.get(TextButton.TextButtonStyle.class));
+            addGamepadButtonOrder(spinnerMouseButton1, mouseButton1Label);
 
-        Label mouseButton3Label = new Label(StringManager.get("screens.OptionsScreen.mouseButton3Label"), skin.get(Label.LabelStyle.class));
-        mainTable.add(mouseButton3Label);
-        mainTable.add(spinnerMouseButton3);
-        mainTable.row();
+            spinnerMouseButton2 = new ActionSpinnerButton(Options.instance.mouseButton2Action, skin.get(TextButton.TextButtonStyle.class));
 
-        addGamepadButtonOrder(spinnerMouseButton3, mouseButton3Label);
+            Label mouseButton2Label = new Label(StringManager.get("screens.OptionsScreen.mouseButton2Label"), skin.get(Label.LabelStyle.class));
+            mainTable.add(mouseButton2Label);
+            mainTable.add(spinnerMouseButton2);
+            mainTable.row();
 
-        // Mouse Scroller
+            addGamepadButtonOrder(spinnerMouseButton2, mouseButton2Label);
 
-        Label mouseScrollLabel = new Label(StringManager.get("screens.OptionsScreen.mouseScrollLabel"), skin.get(Label.LabelStyle.class));
-        mainTable.add(mouseScrollLabel);
+            spinnerMouseButton3 = new ActionSpinnerButton(Options.instance.mouseButton3Action, skin.get(TextButton.TextButtonStyle.class));
 
-        chkMouseScroller = new CheckBox("", skin.get(CheckBox.CheckBoxStyle.class));
-        chkMouseScroller.setChecked(options.useMouseScroller);
+            Label mouseButton3Label = new Label(StringManager.get("screens.OptionsScreen.mouseButton3Label"), skin.get(Label.LabelStyle.class));
+            mainTable.add(mouseButton3Label);
+            mainTable.add(spinnerMouseButton3);
+            mainTable.row();
 
-        mainTable.add(chkMouseScroller);
-        mainTable.row();
+            addGamepadButtonOrder(spinnerMouseButton3, mouseButton3Label);
 
-        addGamepadButtonOrder(chkMouseScroller, mouseScrollLabel);
+            // Mouse Scroller
+
+            Label mouseScrollLabel = new Label(StringManager.get("screens.OptionsScreen.mouseScrollLabel"), skin.get(Label.LabelStyle.class));
+            mainTable.add(mouseScrollLabel);
+
+            chkMouseScroller = new CheckBox("", skin.get(CheckBox.CheckBoxStyle.class));
+            chkMouseScroller.setChecked(options.useMouseScroller);
+
+            mainTable.add(chkMouseScroller);
+            mainTable.row();
+
+            addGamepadButtonOrder(chkMouseScroller, mouseScrollLabel);
+        }
 
         // Button Row
 
         Table buttonTable = new Table();
 
         buttonTable.add(backBtn);
-        buttonTable.add(keysBtn);
+
+        if (!GameApplication.isMobile()) {
+            buttonTable.add(keysBtn);
+            buttonTable.getCell(keysBtn).padRight(4);
+        }
+
         buttonTable.add(gamepadBtn);
 
         buttonTable.getCell(backBtn).padRight(4);
-        buttonTable.getCell(keysBtn).padRight(4);
         buttonTable.pack();
 
         buttonOrder.add(backBtn);
-        buttonOrder.add(keysBtn);
+
+        if (!GameApplication.isMobile()) {
+            buttonOrder.add(keysBtn);
+        }
+
         buttonOrder.add(gamepadBtn);
 
         mainTable.add(buttonTable);
@@ -210,13 +224,15 @@ public class OptionsInputOverlay extends WindowOverlay {
             valueLookXLast = sliderLookX.getValue();
         }
 
-        if((valueLookYLast != sliderLookY.getValue()) || (invertLookLastValue != invertLook.isChecked())) {
-            valueLookYLast = sliderLookY.getValue();
-            invertLookLastValue = invertLook.isChecked();
-        }
+        if (!GameApplication.isMobile()) {
+            if((valueLookYLast != sliderLookY.getValue()) || (invertLookLastValue != invertLook.isChecked())) {
+                valueLookYLast = sliderLookY.getValue();
+                invertLookLastValue = invertLook.isChecked();
+            }
 
-        if(mouseScrollerLastValue != chkMouseScroller.isChecked()) {
-            mouseScrollerLastValue = chkMouseScroller.isChecked();
+            if (mouseScrollerLastValue != chkMouseScroller.isChecked()) {
+                mouseScrollerLastValue = chkMouseScroller.isChecked();
+            }
         }
 
         // back
@@ -240,12 +256,15 @@ public class OptionsInputOverlay extends WindowOverlay {
     }
 
     public void saveOptions() {
-        Options.instance.mouseInvert = invertLook.isChecked();
         Options.instance.mouseXSensitivity = sliderLookX.getValue();
         Options.instance.mouseYSensitivity = sliderLookY.getValue();
-        Options.instance.mouseButton1Action = spinnerMouseButton1.getValue();
-        Options.instance.mouseButton2Action = spinnerMouseButton2.getValue();
-        Options.instance.mouseButton3Action = spinnerMouseButton3.getValue();
+
+        if (!GameApplication.isMobile()) {
+            Options.instance.mouseInvert = invertLook.isChecked();
+            Options.instance.mouseButton1Action = spinnerMouseButton1.getValue();
+            Options.instance.mouseButton2Action = spinnerMouseButton2.getValue();
+            Options.instance.mouseButton3Action = spinnerMouseButton3.getValue();
+        }
 
         Options.saveOptions();
     }

--- a/core/src/main/java/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
@@ -39,6 +39,8 @@ public class OptionsOverlay extends WindowOverlay {
 
     private CheckBox fullscreenMode;
 
+    private Slider sliderLookSpeed;
+
     private String[] graphicsLabelValues = {
             StringManager.get("screens.OptionsScreen.graphicsLow"),
             StringManager.get("screens.OptionsScreen.graphicsMedium"),
@@ -270,10 +272,27 @@ public class OptionsOverlay extends WindowOverlay {
             mainTable.row();
         }
 
+        // Unified look speed slider for mobile
+        if (GameApplication.isMobile()) {
+            sliderLookSpeed  = new Slider(0.1f, 3f, 0.001f, false, skin.get(Slider.SliderStyle.class));
+            sliderLookSpeed.setValue(options.mouseXSensitivity);
+
+            Label lookSpeedLabel = new Label(StringManager.get("screens.OptionsScreen.lookSpeedLabel"), skin.get(Label.LabelStyle.class));
+            mainTable.add(lookSpeedLabel);
+            mainTable.add(sliderLookSpeed);
+            mainTable.row();
+
+            addGamepadButtonOrder(sliderLookSpeed, lookSpeedLabel);
+        }
+
         // Button Bar
         Table buttonTable = new Table();
         buttonTable.add(backBtn).padRight(4f);
-        buttonTable.add(controlsBtn).padRight(4f);
+
+        if (!GameApplication.isMobile()) {
+            buttonTable.add(controlsBtn).padRight(4f);
+        }
+
         buttonTable.add(graphicsBtn).padRight(4f);
         buttonTable.pack();
 
@@ -373,6 +392,12 @@ public class OptionsOverlay extends WindowOverlay {
         Options.instance.headBobEnabled = headBob.isChecked();
         Options.instance.handLagEnabled = handLag.isChecked();
         if(fullscreenMode != null) Options.instance.fullScreen = fullscreenMode.isChecked();
+
+        if (sliderLookSpeed != null) {
+            Options.instance.mouseXSensitivity = sliderLookSpeed.getValue();
+            Options.instance.mouseYSensitivity = sliderLookSpeed.getValue();
+        }
+
         Options.saveOptions();
     }
 }

--- a/core/src/main/java/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
@@ -197,6 +197,19 @@ public class OptionsOverlay extends WindowOverlay {
         mainTable.add(showUI);
         mainTable.row();
 
+        // Look speed slider for mobile
+        if (GameApplication.isMobile()) {
+            sliderLookSpeed  = new Slider(0.1f, 3f, 0.001f, false, skin.get(Slider.SliderStyle.class));
+            sliderLookSpeed.setValue(options.mouseXSensitivity);
+
+            Label lookSpeedLabel = new Label(StringManager.get("screens.OptionsScreen.lookSpeedLabel"), skin.get(Label.LabelStyle.class));
+            mainTable.add(lookSpeedLabel);
+            mainTable.add(sliderLookSpeed);
+            mainTable.row();
+
+            addGamepadButtonOrder(sliderLookSpeed, lookSpeedLabel);
+        }
+
         // Show Crosshair
         Label showCrosshairLabel = new Label(StringManager.get("screens.OptionsScreen.showCrosshairLabel"),skin.get(Label.LabelStyle.class));
         mainTable.add(showCrosshairLabel);
@@ -270,19 +283,6 @@ public class OptionsOverlay extends WindowOverlay {
             addGamepadButtonOrder(fullscreenMode, fullScreenLabel);
 
             mainTable.row();
-        }
-
-        // Unified look speed slider for mobile
-        if (GameApplication.isMobile()) {
-            sliderLookSpeed  = new Slider(0.1f, 3f, 0.001f, false, skin.get(Slider.SliderStyle.class));
-            sliderLookSpeed.setValue(options.mouseXSensitivity);
-
-            Label lookSpeedLabel = new Label(StringManager.get("screens.OptionsScreen.lookSpeedLabel"), skin.get(Label.LabelStyle.class));
-            mainTable.add(lookSpeedLabel);
-            mainTable.add(sliderLookSpeed);
-            mainTable.row();
-
-            addGamepadButtonOrder(sliderLookSpeed, lookSpeedLabel);
         }
 
         // Button Bar

--- a/core/src/main/java/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/overlays/OptionsOverlay.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Align;
 import com.interrupt.dungeoneer.Audio;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.entities.Player;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Options;
@@ -242,7 +243,7 @@ public class OptionsOverlay extends WindowOverlay {
         }
 
         // Fullscreen Mode
-        if(!(Gdx.app.getType() == Application.ApplicationType.Android || Gdx.app.getType() == Application.ApplicationType.iOS)) {
+        if(!GameApplication.isMobile()) {
             fullscreenMode = new CheckBox("", skin.get(CheckBox.CheckBoxStyle.class));
             fullscreenMode.setChecked(Options.instance.fullScreen);
 

--- a/core/src/main/java/com/interrupt/dungeoneer/overlays/WindowOverlay.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/overlays/WindowOverlay.java
@@ -17,6 +17,7 @@ import com.badlogic.gdx.utils.ArrayMap;
 import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
 import com.interrupt.dungeoneer.Audio;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.game.Colors;
 import com.interrupt.dungeoneer.game.Game;
@@ -328,7 +329,7 @@ public abstract class WindowOverlay extends Overlay {
 
 		uiScale *= Math.min(1f, Options.instance.uiSize);
 
-		if(!Game.isMobile) uiScale *= 0.75f;
+		if(!GameApplication.isMobile()) uiScale *= 0.75f;
 
 		renderer = GameManager.renderer;
 		gl = renderer.getGL();

--- a/core/src/main/java/com/interrupt/dungeoneer/screens/BaseScreen.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/screens/BaseScreen.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.utils.viewport.FillViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.interrupt.api.steam.SteamApi;
 import com.interrupt.dungeoneer.Art;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Level;
@@ -146,7 +147,7 @@ public class BaseScreen implements Screen {
 	@Override
 	public void pause() {
 		Gdx.app.log(screenName, "LibGdx Pause");
-		if(Game.isMobile)
+		if(GameApplication.isMobile())
 			running = false;
 	}
 

--- a/core/src/main/java/com/interrupt/dungeoneer/screens/GameScreen.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/screens/GameScreen.java
@@ -112,7 +112,7 @@ public class GameScreen implements Screen {
 
 	@Override
 	public void pause() {
-		if(Game.isMobile) {
+		if(GameApplication.isMobile()) {
 			Gdx.app.log("DelverGameScreen", "LibGdx Pause");
 			doPause();
 		}
@@ -158,7 +158,7 @@ public class GameScreen implements Screen {
 
 	@Override
 	public void resume() {
-		if(Game.isMobile) {
+		if(GameApplication.isMobile()) {
 			Gdx.app.log("DelverGameScreen", "Resume");
 
 			resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
@@ -201,10 +201,10 @@ public class GameScreen implements Screen {
 				Audio.playMusic(Game.instance.level.music, Game.instance.level.loopMusic);
 		}
 
-		if(Game.instance.level.ambientSound != null && !Game.isMobile)
+		if(Game.instance.level.ambientSound != null && !GameApplication.isMobile())
 			Audio.playAmbientSound(Game.instance.level.ambientSound, Game.instance.level.ambientSoundVolume, 0.1f);
 
-		if(Game.isMobile) Gdx.input.setCatchKey(Input.Keys.BACK, true );
+		if(GameApplication.isMobile()) Gdx.input.setCatchKey(Input.Keys.BACK, true );
 
 		Gdx.app.log("DelverGameScreen", "Finished showing");
 	}
@@ -215,7 +215,7 @@ public class GameScreen implements Screen {
 
 		doPause();
 
-		if(Game.isMobile) Gdx.input.setCatchKey(Input.Keys.BACK, true );
+		if(GameApplication.isMobile()) Gdx.input.setCatchKey(Input.Keys.BACK, true );
 		Audio.stopLoopingSounds();
 
 		if(editorLevel != null) GameApplication.editorRunning = false;

--- a/core/src/main/java/com/interrupt/dungeoneer/ui/CharacterScreen.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/ui/CharacterScreen.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.Align;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.entities.Player;
 import com.interrupt.dungeoneer.game.Colors;
 import com.interrupt.dungeoneer.game.Game;
@@ -41,7 +42,7 @@ public class CharacterScreen {
         uiScale *= Game.getDynamicUiScale();
 
         // Scale up for mobile
-        if(Game.isMobile)
+        if(GameApplication.isMobile())
             uiScale *= Game.GetMobileUiScalingBoost();
 
         fontScale = 2f;

--- a/core/src/main/java/com/interrupt/dungeoneer/ui/EquipLoc.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/ui/EquipLoc.java
@@ -14,6 +14,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Button;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.interrupt.dungeoneer.GameManager;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameInput;
 import com.interrupt.dungeoneer.collision.Collidor;
 import com.interrupt.dungeoneer.entities.Item;
@@ -116,14 +117,14 @@ public class EquipLoc {
 
 		if(!visible) return;
 
-		if(Game.isMobile || !Game.instance.input.caughtCursor) {
+		if(GameApplication.isMobile() || !Game.instance.input.caughtCursor) {
 			int x = 0;
 			int y = 0;
 
 			float xPos1 = -((uiSize * 1) / 2.0f) + uiSize * x;
 			float xPosD = xPos1 + (xOffset * uiSize);
 
-			if((Game.isMobile || !input.caughtCursor) && xCursorPos > xPosD && xCursorPos <= xPosD + uiSize && yCursorPos <= ((y + 1) * uiSize) + (yOffset * uiSize) && yCursorPos > (y * uiSize) + (yOffset * uiSize))
+			if((GameApplication.isMobile() || !input.caughtCursor) && xCursorPos > xPosD && xCursorPos <= xPosD + uiSize && yCursorPos <= ((y + 1) * uiSize) + (yOffset * uiSize) && yCursorPos > (y * uiSize) + (yOffset * uiSize))
 			{
 				isHovered = true;
 			}

--- a/core/src/main/java/com/interrupt/dungeoneer/ui/Hotbar.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/ui/Hotbar.java
@@ -2,6 +2,7 @@ package com.interrupt.dungeoneer.ui;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameInput;
 import com.interrupt.dungeoneer.entities.Item;
 import com.interrupt.dungeoneer.game.Game;
@@ -144,7 +145,7 @@ public class Hotbar {
             return;
 
         // We are able to drag inventory items whenever in mobile mode, or whenever the cursor is showing
-        boolean canDrag = Game.isMobile || !Game.instance.input.caughtCursor;
+        boolean canDrag = GameApplication.isMobile() || !Game.instance.input.caughtCursor;
 
         // If we can drag, figure out which inventory slot the cursor is over
         if (canDrag) {

--- a/core/src/main/java/com/interrupt/dungeoneer/ui/InventoryItemButton.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/ui/InventoryItemButton.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Button;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.GameInput;
 import com.interrupt.dungeoneer.GameManager;
 import com.interrupt.dungeoneer.collision.Collidor;
@@ -90,7 +91,7 @@ public class InventoryItemButton extends Button {
     }
 
     public void setCursorVisibility(boolean visible) {
-        if(Game.isMobile || gameInput.showingGamepadCursor)
+        if(GameApplication.isMobile() || gameInput.showingGamepadCursor)
             return;
 
         if(visible) {

--- a/core/src/main/java/com/interrupt/dungeoneer/ui/InventoryScreen.java
+++ b/core/src/main/java/com/interrupt/dungeoneer/ui/InventoryScreen.java
@@ -8,6 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.Align;
+import com.interrupt.dungeoneer.GameApplication;
 import com.interrupt.dungeoneer.entities.Player;
 import com.interrupt.dungeoneer.game.Game;
 import com.interrupt.dungeoneer.game.Options;
@@ -32,7 +33,7 @@ public class InventoryScreen {
         uiScale *= Game.getDynamicUiScale();
 
         // Scale up for mobile
-        if(Game.isMobile)
+        if(GameApplication.isMobile())
             uiScale *= Game.GetMobileUiScalingBoost();
 
         fontScale = 2f;


### PR DESCRIPTION
<img width="1321" height="925" alt="Screenshot 2025-10-23 at 11 11 44 AM" src="https://github.com/user-attachments/assets/899cdbcc-f7ee-459d-b23e-94b1da0c0378" />
<img width="1321" height="925" alt="Screenshot 2025-10-23 at 11 13 27 AM" src="https://github.com/user-attachments/assets/8a0980d5-4a34-4874-83b6-603f9c92d5a5" />
<img width="1321" height="925" alt="Screenshot 2025-10-23 at 11 16 00 AM" src="https://github.com/user-attachments/assets/440685d0-9b7a-49de-aa27-362ec9ee77ff" />

## Summary
Hides options/overlays that do not apply to mobile versions of Delver Engine.

## PR Guide
### GameApplication.java
This changed touched quite a few files. This is needed to unify how we check for isMobile. It was changed to a function and moved to the GameApplication because in the main menu the Game object is null.

### OptionsOverlay.java
- Hid the fullscreen button

### OptionsInputOverlay.java
- Hid invert look checkbox
- Hid mouse button one spinner
- Hid mouse button two spinner
- Hid mouse button three spinner
- Hid mouse scroll checkbox
- Hid keys button

### OptionsGraphicsOverlay.java
- Hid renderer spinner
- Hid vsync checkbox
- Hid limit fps checkbox