### PR TITLE
Enable stencil buffers on mobile

### DIFF
--- a/android/src/main/java/com/interrupt/dungeoneer/android/DungeoneerAndroidActivity.java
+++ b/android/src/main/java/com/interrupt/dungeoneer/android/DungeoneerAndroidActivity.java
@@ -14,6 +14,7 @@ public class DungeoneerAndroidActivity extends AndroidApplication {
         super.onCreate(savedInstanceState);
         AndroidApplicationConfiguration configuration = new AndroidApplicationConfiguration();
         configuration.useImmersiveMode = true; // Recommended, but not required.
+        configuration.stencil = 8;
 
         // Enable debug mode for debug builds
         Game.isDebugMode = (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;

--- a/ios/src/main/java/com/interrupt/dungeoneer/IOSLauncher.java
+++ b/ios/src/main/java/com/interrupt/dungeoneer/IOSLauncher.java
@@ -1,6 +1,8 @@
 package com.interrupt.dungeoneer;
 
+import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import org.robovm.apple.foundation.NSAutoreleasePool;
+import org.robovm.apple.glkit.GLKViewDrawableStencilFormat;
 import org.robovm.apple.uikit.UIApplication;
 
 import com.badlogic.gdx.backends.iosrobovm.IOSApplication;
@@ -12,6 +14,9 @@ public class IOSLauncher extends IOSApplication.Delegate {
     @Override
     protected IOSApplication createApplication() {
         IOSApplicationConfiguration configuration = new IOSApplicationConfiguration();
+        configuration.orientationPortrait = false;
+        configuration.hdpiMode = HdpiMode.Pixels;
+        configuration.stencilFormat = GLKViewDrawableStencilFormat._8;
         return new IOSApplication(new GameApplication(), configuration);
     }
 


### PR DESCRIPTION
<img width="2556" height="1179" alt="image" src="https://github.com/user-attachments/assets/811a162c-c173-4c1a-8374-8573d8741351" />
<img width="2556" height="1179" alt="image" src="https://github.com/user-attachments/assets/8004becc-45c1-4886-b90d-a277386b2506" />

## Summary
Enables stencil buffers for mobile devices.